### PR TITLE
add r2 to lead value for functional variants in relaxed group

### DIFF
--- a/Scripts/compare.py
+++ b/Scripts/compare.py
@@ -153,8 +153,8 @@ def create_top_level_report(report_df,efo_traits,columns,grouping_method,signifi
         cred_s = loc_variants.loc[~loc_variants["cs_id"].isna(),["#variant","cs_prob"] ].drop_duplicates()
         cred_set=";".join( "{}|{:.3g}".format(t._1,t.cs_prob) for t in  cred_s.itertuples() )
         try:
-            func_s = loc_variants.loc[~loc_variants["functional_category"].isna(),["#variant","functional_category"] ].drop_duplicates()
-            func_set=";".join("{}|{}".format(t._1,t.functional_category) for t in  func_s.itertuples())
+            func_s = loc_variants.loc[~loc_variants["functional_category"].isna(),["#variant","functional_category","r2_to_lead"] ].drop_duplicates()
+            func_set=";".join("{}|{}|{:.3g}".format(t._1,t.functional_category,t.r2_to_lead) for t in  func_s.itertuples())
             func_s_strict = strict_group.loc[~strict_group["functional_category"].isna(),["#variant","functional_category"] ].drop_duplicates()
             func_set_strict=";".join("{}|{}".format(t._1,t.functional_category) for t in  func_s_strict.itertuples())
         except:


### PR DESCRIPTION
This PR aims to fix #66 

I'm a bit uncertain on the status of r2 values on strict columns (found_associations_strict, functional_variants_strict). Currently the found_associations_strict-column has these values, when it might not be necessary (the variants are in the credible set/stricter subset in case of LD grouping). @Fedja should r2 values be removed from strict (credible set/stricter LD group) columns?