### PR TITLE
Draft: error handling in autoreporting tool

### DIFF
--- a/Scripts/annotate.py
+++ b/Scripts/annotate.py
@@ -198,8 +198,14 @@ if __name__=="__main__":
     parser.add_argument("--annotate-out",dest="annotate_out",type=str,default="annotate_out.tsv",help="Output filename, default is out.tsv")
     parser.add_argument("--column-labels",dest="column_labels",metavar=("CHROM","POS","REF","ALT","PVAL","BETA","AF"),nargs=7,default=["#chrom","pos","ref","alt","pval","beta","maf"],help="Names for data file columns. Default is '#chrom pos ref alt pval beta maf'.")
     parser.add_argument("--finngen-annotation-version",dest="fg_ann_version",type=str,default="r3",help="Finngen annotation release version: 3 or under or 4 or higher? Allowed values: 'r3' and 'r4'. Default 'r3' ")
+    parser.add_argument("--loglevel",dest="loglevel",type=str,default="warning",help="Level at which events are logged. Use values info, debug, warning, error, critical" )
+
     args=parser.parse_args()
-    columns=autoreporting_utils.columns_from_arguments(args.column_labels)
+    loglevel=getattr(logging, args.loglevel.upper() )
+    logging.basicConfig(level=loglevel)
+    log_arguments(args)
+    
+    columns=columns_from_arguments(args.column_labels)
     if args.prefix!="":
         args.prefix=args.prefix+"."
     args.annotate_out = "{}{}".format(args.prefix,args.annotate_out)

--- a/Scripts/autoreporting_utils.py
+++ b/Scripts/autoreporting_utils.py
@@ -2,6 +2,7 @@ import argparse,shlex,subprocess, os
 from subprocess import Popen, PIPE
 import pandas as pd, numpy as np
 import tabix
+import logging
 
 """
 Utility functions that are used in the scripts, put here for keeping the code clearer
@@ -106,3 +107,10 @@ def columns_from_arguments(column_labels):
     Out: Dictionary with the members 'chrom','pos','ref','alt','pval', 'beta', 'af'
     """
     return {"chrom":column_labels[0],"pos":column_labels[1],"ref":column_labels[2],"alt":column_labels[3],"pval":column_labels[4],"beta":column_labels[5],"af":column_labels[6]}
+
+def log_arguments(args):
+    logger= logging.getLogger(__name__)
+    arguments=vars(args)
+    logger.info("Used arguments:")
+    for key, value in arguments.items():
+        logger.info("       {}: {}".format(key,value))

--- a/Scripts/compare.py
+++ b/Scripts/compare.py
@@ -482,8 +482,15 @@ if __name__ == "__main__":
     parser.add_argument("--efo-codes",dest="efo_traits",type=str,nargs="+",default=[],help="Specific EFO codes to look for in the top level report")
     parser.add_argument("--local-gwascatalog",dest='localdb_path',type=str,help="Path to local GWAS Catalog DB.")
     parser.add_argument("--db",dest="database_choice",type=str,default="gwas",help="Database to use for comparison. use 'local','gwas' or 'summary_stats'.")
+    parser.add_argument("--loglevel",dest="loglevel",type=str,default="warning",help="Level at which events are logged. Use values info, debug, warning, error, critical" )
+
     args=parser.parse_args()
-    columns=autoreporting_utils.columns_from_arguments(args.column_labels)
+    loglevel=getattr(logging, args.loglevel.upper() )
+    logging.basicConfig(level=loglevel)
+    log_arguments(args)
+
+    columns=columns_from_arguments(args.column_labels)
+
     if args.prefix!="":
         args.prefix=args.prefix+"."
     args.report_out = "{}{}".format(args.prefix,args.report_out)

--- a/Scripts/gws_fetch.py
+++ b/Scripts/gws_fetch.py
@@ -168,7 +168,7 @@ def get_gws_variants(fname, sign_treshold=5e-8,dtype=None,columns={"chrom":"#chr
     retval=pd.DataFrame()
     try:
         for df in pd.read_csv(fname,compression=compression,sep="\t",dtype=dtype,engine="c",chunksize=chunksize):
-            retval=pd.concat( [retval,df.loc[df[columns["pval"] ] <=sign_treshold,: ] ], axis="index", ignore_index=True ) 
+            retval=pd.concat( [retval,df.loc[df[columns["pval"] ] <=sign_treshold,: ] ], axis="index", ignore_index=True,sort=False ) 
             retval=retval[ [ columns["chrom"],columns["pos"],columns["ref"],columns["alt"],columns["pval"], columns["beta"],columns["af"] ] ]
     except KeyError:
         logger=logging.getLogger(__name__)
@@ -291,8 +291,14 @@ if __name__=="__main__":
     parser.add_argument("--ignore-region",dest="ignore_region",type=str,default="",help="Ignore the given region, e.g. HLA region, from analysis. Give in CHROM:BPSTART-BPEND format.")
     parser.add_argument("--credible-set-file",dest="cred_set_file",type=str,default="",help="bgzipped SuSiE credible set file.")
     parser.add_argument("--ld-api",dest="ld_api_choice",type=str,default="plink",help="LD interface to use. Valid options are 'plink' and 'online'.")
+    parser.add_argument("--loglevel",dest="loglevel",type=str,default="warning",help="Level at which events are logged. Use values info, debug, warning, error, critical" )
+
     args=parser.parse_args()
-    columns=autoreporting_utils.columns_from_arguments(args.column_labels)
+    loglevel=getattr(logging, args.loglevel.upper() )
+    logging.basicConfig(level=loglevel)
+    log_arguments(args)
+    
+    columns=columns_from_arguments(args.column_labels)
     if args.prefix!="":
         args.prefix=args.prefix+"."
     args.fetch_out = "{}{}".format(args.prefix,args.fetch_out)

--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -7,15 +7,10 @@ import gws_fetch, compare, annotate,autoreporting_utils
 from linkage import PlinkLD, OnlineLD
 import logging
 
-# def die():
-#     trace_fname="error_trace.txt"
-#     with open(trace_fname,"w") as f:
-#         f.write(traceback.format_exc())
-#     return trace_fname
 
 def main(args):
     logger= logging.getLogger(__name__)
-    logger.info("input file: {}".format(args.gws_fpath))
+    autoreporting_utils.log_arguments(args)
     #print()
     args.fetch_out = "{}{}".format(args.prefix,args.fetch_out)
     args.annotate_out = "{}{}".format(args.prefix,args.annotate_out)
@@ -130,7 +125,7 @@ if __name__=="__main__":
     parser.add_argument("--db",dest="database_choice",type=str,default="gwas",help="Database to use for comparison. use 'local','gwas' or 'summary_stats'.")
 
     #other
-    parser.add_argument("--loglevel",dest="loglevel",type=str,default="info",help="loglevel" )
+    parser.add_argument("--loglevel",dest="loglevel",type=str,default="warning",help="Level at which events are logged. Use values info, debug, warning, error, critical" )
     args=parser.parse_args()
     loglevel=getattr(logging, args.loglevel.upper() )
     logging.basicConfig(level=loglevel)


### PR DESCRIPTION
This PR is a draft for how handling could be.

The basic idea is that users do not want to see stack traces, so they aren't printed when the script errors out. Instead, human-readable explanation is printed to stdout where it is possible (aka where the correct variables are available), and the stack trace is printed to a file (and/or stderr?). A return code of 1 will be sent in case of any error, and 0 in case of no errors.

I'd be happy to hear if this sounds sensible, and if there are other possible ways that might be more suitable.

also aims to fix #68 

