### PR TITLE
remove nfe from enrichment calculations so calcs are made with subpopulatons

### DIFF
--- a/Scripts/annotate.py
+++ b/Scripts/annotate.py
@@ -107,10 +107,10 @@ def annotate(df,gnomad_genome_path, gnomad_exome_path, batch_freq, finngen_path,
         gnomad_genomes=gnomad_genomes.drop_duplicates(subset=["#CHROM","POS","REF","ALT"]).rename(columns={"#CHROM":columns["chrom"],"POS":columns["pos"],"REF":columns["ref"],"ALT":columns["alt"]})
         gnomad_genomes["#variant"]=create_variant_column(gnomad_genomes,chrom=columns["chrom"],pos=columns["pos"],ref=columns["ref"],alt=columns["alt"])
         #calculate enrichment for gnomad genomes, nfe, nfe without est
-        gn_gen_nfe_counts=["AC_nfe","AC_nfe_est","AC_nfe_nwe","AC_nfe_onf","AC_nfe_seu"]
-        gn_gen_nfe_nums=["AN_nfe","AN_nfe_est","AN_nfe_nwe","AN_nfe_onf","AN_nfe_seu"]
-        gn_gen_nfe_est_counts=["AC_nfe","AC_nfe_nwe","AC_nfe_onf","AC_nfe_seu"]
-        gn_gen_nfe_est_nums=["AN_nfe","AN_nfe_nwe","AN_nfe_onf","AN_nfe_seu"]
+        gn_gen_nfe_counts=["AC_nfe_est","AC_nfe_nwe","AC_nfe_onf","AC_nfe_seu"]
+        gn_gen_nfe_nums=["AN_nfe_est","AN_nfe_nwe","AN_nfe_onf","AN_nfe_seu"]
+        gn_gen_nfe_est_counts=["AC_nfe_nwe","AC_nfe_onf","AC_nfe_seu"]
+        gn_gen_nfe_est_nums=["AN_nfe_nwe","AN_nfe_onf","AN_nfe_seu"]
         #calculate enrichment
         
         gnomad_genomes.loc[:,"FI_enrichment_nfe"]=calculate_enrichment(gnomad_genomes,"AF_fin",gn_gen_nfe_counts,gn_gen_nfe_nums)
@@ -123,14 +123,14 @@ def annotate(df,gnomad_genome_path, gnomad_exome_path, batch_freq, finngen_path,
         gnomad_exomes=gnomad_exomes.drop_duplicates(subset=["#CHROM","POS","REF","ALT"]).rename(columns={"#CHROM":columns["chrom"],"POS":columns["pos"],"REF":columns["ref"],"ALT":columns["alt"]})
         gnomad_exomes["#variant"]=create_variant_column(gnomad_exomes,chrom=columns["chrom"],pos=columns["pos"],ref=columns["ref"],alt=columns["alt"])
         #calculate enrichment for gnomax exomes, nfe, nfe without est, nfe without swe, nfe without est, swe?
-        gn_exo_nfe_counts=["AC_nfe","AC_nfe_bgr","AC_nfe_est","AC_nfe_onf","AC_nfe_seu","AC_nfe_swe"]
-        gn_exo_nfe_nums=["AN_nfe","AN_nfe_bgr","AN_nfe_est","AN_nfe_onf","AN_nfe_seu","AN_nfe_swe"]
-        gn_exo_nfe_est_counts=["AC_nfe","AC_nfe_bgr","AC_nfe_onf","AC_nfe_seu","AC_nfe_swe"]
-        gn_exo_nfe_est_nums=["AN_nfe","AN_nfe_bgr","AN_nfe_onf","AN_nfe_seu","AN_nfe_swe"]
-        gn_exo_nfe_swe_counts=["AC_nfe","AC_nfe_bgr","AC_nfe_est","AC_nfe_onf","AC_nfe_seu"]
-        gn_exo_nfe_swe_nums=["AN_nfe","AN_nfe_bgr","AN_nfe_est","AN_nfe_onf","AN_nfe_seu"]
-        gn_exo_nfe_est_swe_counts=["AC_nfe","AC_nfe_bgr","AC_nfe_onf","AC_nfe_seu"]
-        gn_exo_nfe_est_swe_nums=["AN_nfe","AN_nfe_bgr","AN_nfe_onf","AN_nfe_seu"]
+        gn_exo_nfe_counts=["AC_nfe_bgr","AC_nfe_est","AC_nfe_onf","AC_nfe_seu","AC_nfe_swe"]
+        gn_exo_nfe_nums=["AN_nfe_bgr","AN_nfe_est","AN_nfe_onf","AN_nfe_seu","AN_nfe_swe"]
+        gn_exo_nfe_est_counts=["AC_nfe_bgr","AC_nfe_onf","AC_nfe_seu","AC_nfe_swe"]
+        gn_exo_nfe_est_nums=["AN_nfe_bgr","AN_nfe_onf","AN_nfe_seu","AN_nfe_swe"]
+        gn_exo_nfe_swe_counts=["AC_nfe_bgr","AC_nfe_est","AC_nfe_onf","AC_nfe_seu"]
+        gn_exo_nfe_swe_nums=["AN_nfe_bgr","AN_nfe_est","AN_nfe_onf","AN_nfe_seu"]
+        gn_exo_nfe_est_swe_counts=["AC_nfe_bgr","AC_nfe_onf","AC_nfe_seu"]
+        gn_exo_nfe_est_swe_nums=["AN_nfe_bgr","AN_nfe_onf","AN_nfe_seu"]
     
         gnomad_exomes.loc[:,"FI_enrichment_nfe"]=calculate_enrichment(gnomad_exomes,"AF_fin",gn_exo_nfe_counts,gn_exo_nfe_nums)
         gnomad_exomes.loc[:,"FI_enrichment_nfe_est"]=calculate_enrichment(gnomad_exomes,"AF_fin",gn_exo_nfe_est_counts,gn_exo_nfe_est_nums)

--- a/testing/annotate_resources/ann_validate_1.csv
+++ b/testing/annotate_resources/ann_validate_1.csv
@@ -1,5 +1,5 @@
 #chrom	pos	ref	alt	rsids	nearest_genes	pval	beta	sebeta	maf	maf_cases	maf_controls	#variant	locus_id	GENOME_AF_fin	GENOME_AF_nfe	GENOME_AF_nfe_est	GENOME_AF_nfe_nwe	GENOME_AF_nfe_onf	GENOME_AF_nfe_seu	GENOME_FI_enrichment_nfe	GENOME_FI_enrichment_nfe_est	EXOME_AF_nfe_bgr	EXOME_AF_fin	EXOME_AF_nfe	EXOME_AF_nfe_est	EXOME_AF_nfe_swe	EXOME_AF_nfe_nwe	EXOME_AF_nfe_onf	EXOME_AF_nfe_seu	EXOME_FI_enrichment_nfe	EXOME_FI_enrichment_nfe_est	EXOME_FI_enrichment_nfe_swe	EXOME_FI_enrichment_nfe_est_swe	functional_category	most_severe_gene	most_severe_consequence
-1	1	A	G	rs1111	GENE1	0.1	0.1	0.1	0.1	0.2	0.1	chr1_1_A_G	chr1_1_A_G	0.07	0.09	0.1	0.11	0.12	0.13	0.636363636363636	0.622222222222222															
-1	10	T	C	rs1112	GENE1	0.1	0.1	0.1	1.1	0.2	0.1	chr1_10_T_C	chr1_10_T_C	0.17	0.19	0.2	0.21	0.22	0.23	0.80952380952381	0.8															
-4	4	C	T	rs1113	GENE2	1E-06	0.2	0.1	2.1	0.3	0.1	chr4_4_C_T	chr4_4_C_T									0.13	0.1	0.12	0.14	0.18	0.15	0.16	0.17	0.666666666666667	0.657894736842105	0.694444444444444	0.689655172413793			
-4	40	G	A	rs1114	GENE2	1E-06	0.2	0.1	3.1	0.3	0.1	chr4_40_G_A	chr4_40_G_A									0.23	0.2	0.22	0.24	0.28	0.25	0.26	0.27	0.8	0.793650793650794	0.819672131147541	0.816326530612245			
+1	1	A	G	rs1111	GENE1	0.1	0.1	0.1	0.1	0.2	0.1	chr1_1_A_G	chr1_1_A_G	0.07	0.09	0.1	0.11	0.12	0.13	0.6086956521739131	0.5833333333333335															
+1	10	T	C	rs1112	GENE1	0.1	0.1	0.1	1.1	0.2	0.1	chr1_10_T_C	chr1_10_T_C	0.17	0.19	0.2	0.21	0.22	0.23	0.7906976744186046	0.7727272727272728															
+4	4	C	T	rs1113	GENE2	1e-06	0.2	0.1	2.1	0.3	0.1	chr4_4_C_T	chr4_4_C_T									0.13	0.1	0.12	0.14	0.18	0.15	0.16	0.17	0.6410256410256411	0.625	0.6666666666666666	0.6521739130434783			
+4	40	G	A	rs1114	GENE2	1e-06	0.2	0.1	3.1	0.3	0.1	chr4_40_G_A	chr4_40_G_A									0.23	0.2	0.22	0.24	0.28	0.25	0.26	0.27	0.78125	0.7692307692307693	0.8	0.7894736842105263			

--- a/testing/annotate_resources/ann_validate_2.csv
+++ b/testing/annotate_resources/ann_validate_2.csv
@@ -1,5 +1,5 @@
 #chrom	pos	ref	alt	rsids	nearest_genes	pval	beta	sebeta	maf	maf_cases	maf_controls	#variant	locus_id	GENOME_AF_fin	GENOME_AF_nfe	GENOME_AF_nfe_est	GENOME_AF_nfe_nwe	GENOME_AF_nfe_onf	GENOME_AF_nfe_seu	GENOME_FI_enrichment_nfe	GENOME_FI_enrichment_nfe_est	EXOME_AF_nfe_bgr	EXOME_AF_fin	EXOME_AF_nfe	EXOME_AF_nfe_est	EXOME_AF_nfe_swe	EXOME_AF_nfe_nwe	EXOME_AF_nfe_onf	EXOME_AF_nfe_seu	EXOME_FI_enrichment_nfe	EXOME_FI_enrichment_nfe_est	EXOME_FI_enrichment_nfe_swe	EXOME_FI_enrichment_nfe_est_swe	functional_category	most_severe_gene	most_severe_consequence
-4	4	C	T	rs1113	GENE2	1E-06	0.2	0.1	2.1	0.3	0.1	chr4_4_C_T	chr4_4_C_T									0.13	0.1	0.12	0.14	0.18	0.15	0.16	0.17	0.666666666666667	0.657894736842105	0.694444444444444	0.689655172413793			
-4	40	G	A	rs1114	GENE2	1E-06	0.2	0.1	3.1	0.3	0.1	chr4_40_G_A	chr4_40_G_A									0.23	0.2	0.22	0.24	0.28	0.25	0.26	0.27	0.8	0.793650793650794	0.819672131147541	0.816326530612245			
-23	23	G	C	rs1115	GENE3	1E-08	0.3	0.1	4.1	0.4	0.1	chr23_23_G_C	chr23_23_G_C																						GENE3	non_coding_transcript_exon_variant
-23	230	C	G	rs1116	GENE3	1E-08	0.3	0.1	5.1	0.4	0.1	chr23_230_C_G	chr23_230_C_G																						GENE3	missense_variant
+4	4	C	T	rs1113	GENE2	1e-06	0.2	0.1	2.1	0.3	0.1	chr4_4_C_T	chr4_4_C_T									0.13	0.1	0.12	0.14	0.18	0.15	0.16	0.17	0.6410256410256411	0.625	0.6666666666666666	0.6521739130434783			
+4	40	G	A	rs1114	GENE2	1e-06	0.2	0.1	3.1	0.3	0.1	chr4_40_G_A	chr4_40_G_A									0.23	0.2	0.22	0.24	0.28	0.25	0.26	0.27	0.78125	0.7692307692307693	0.8	0.7894736842105263			
+23	23	G	C	rs1115	GENE3	1e-08	0.3	0.1	4.1	0.4	0.1	chr23_23_G_C	chr23_23_G_C																						GENE3	non_coding_transcript_exon_variant
+23	230	C	G	rs1116	GENE3	1e-08	0.3	0.1	5.1	0.4	0.1	chr23_230_C_G	chr23_230_C_G																						GENE3	missense_variant

--- a/testing/annotate_resources/ann_validate_3.csv
+++ b/testing/annotate_resources/ann_validate_3.csv
@@ -1,5 +1,5 @@
 #chrom	pos	ref	alt	rsids	nearest_genes	pval	beta	sebeta	maf	maf_cases	maf_controls	#variant	locus_id	GENOME_AF_fin	GENOME_AF_nfe	GENOME_AF_nfe_est	GENOME_AF_nfe_nwe	GENOME_AF_nfe_onf	GENOME_AF_nfe_seu	GENOME_FI_enrichment_nfe	GENOME_FI_enrichment_nfe_est	EXOME_AF_nfe_bgr	EXOME_AF_fin	EXOME_AF_nfe	EXOME_AF_nfe_est	EXOME_AF_nfe_swe	EXOME_AF_nfe_nwe	EXOME_AF_nfe_onf	EXOME_AF_nfe_seu	EXOME_FI_enrichment_nfe	EXOME_FI_enrichment_nfe_est	EXOME_FI_enrichment_nfe_swe	EXOME_FI_enrichment_nfe_est_swe	functional_category	most_severe_gene	most_severe_consequence
-1	1	A	G	rs1111	GENE1	0.1	0.1	0.1	0.1	0.2	0.1	chr1_1_A_G	chr1_1_A_G	0.07	0.09	0.1	0.11	0.12	0.13	0.636363636363636	0.622222222222222															
-1	10	T	C	rs1112	GENE1	0.1	0.1	0.1	1.1	0.2	0.1	chr1_10_T_C	chr1_10_T_C	0.17	0.19	0.2	0.21	0.22	0.23	0.80952380952381	0.8															
-23	23	G	C	rs1115	GENE3	1E-08	0.3	0.1	4.1	0.4	0.1	chr23_23_G_C	chr23_23_G_C																						GENE3	non_coding_transcript_exon_variant
-23	230	C	G	rs1116	GENE3	1E-08	0.3	0.1	5.1	0.4	0.1	chr23_230_C_G	chr23_230_C_G																						GENE3	missense_variant
+1	1	A	G	rs1111	GENE1	0.1	0.1	0.1	0.1	0.2	0.1	chr1_1_A_G	chr1_1_A_G	0.07	0.09	0.1	0.11	0.12	0.13	0.6086956521739131	0.5833333333333335															
+1	10	T	C	rs1112	GENE1	0.1	0.1	0.1	1.1	0.2	0.1	chr1_10_T_C	chr1_10_T_C	0.17	0.19	0.2	0.21	0.22	0.23	0.7906976744186046	0.7727272727272728															
+23	23	G	C	rs1115	GENE3	1e-08	0.3	0.1	4.1	0.4	0.1	chr23_23_G_C	chr23_23_G_C																						GENE3	non_coding_transcript_exon_variant
+23	230	C	G	rs1116	GENE3	1e-08	0.3	0.1	5.1	0.4	0.1	chr23_230_C_G	chr23_230_C_G																						GENE3	missense_variant

--- a/testing/annotate_resources/ann_validate_4.csv
+++ b/testing/annotate_resources/ann_validate_4.csv
@@ -1,7 +1,7 @@
 #chrom	pos	ref	alt	rsids	nearest_genes	pval	beta	sebeta	maf	maf_cases	maf_controls	#variant	locus_id	GENOME_AF_fin	GENOME_AF_nfe	GENOME_AF_nfe_est	GENOME_AF_nfe_nwe	GENOME_AF_nfe_onf	GENOME_AF_nfe_seu	GENOME_FI_enrichment_nfe	GENOME_FI_enrichment_nfe_est	EXOME_AF_nfe_bgr	EXOME_AF_fin	EXOME_AF_nfe	EXOME_AF_nfe_est	EXOME_AF_nfe_swe	EXOME_AF_nfe_nwe	EXOME_AF_nfe_onf	EXOME_AF_nfe_seu	EXOME_FI_enrichment_nfe	EXOME_FI_enrichment_nfe_est	EXOME_FI_enrichment_nfe_swe	EXOME_FI_enrichment_nfe_est_swe	functional_category	most_severe_gene	most_severe_consequence
-1	1	A	G	rs1111	GENE1	0.1	0.1	0.1	0.1	0.2	0.1	chr1_1_A_G	chr1_1_A_G	0.07	0.09	0.1	0.11	0.12	0.13	0.636363636363636	0.622222222222222															
-1	10	T	C	rs1112	GENE1	0.1	0.1	0.1	1.1	0.2	0.1	chr1_10_T_C	chr1_10_T_C	0.17	0.19	0.2	0.21	0.22	0.23	0.80952380952381	0.8															
-4	4	C	T	rs1113	GENE2	1E-06	0.2	0.1	2.1	0.3	0.1	chr4_4_C_T	chr4_4_C_T									0.13	0.1	0.12	0.14	0.18	0.15	0.16	0.17	0.666666666666667	0.657894736842105	0.694444444444444	0.689655172413793			
-4	40	G	A	rs1114	GENE2	1E-06	0.2	0.1	3.1	0.3	0.1	chr4_40_G_A	chr4_40_G_A									0.23	0.2	0.22	0.24	0.28	0.25	0.26	0.27	0.8	0.793650793650794	0.819672131147541	0.816326530612245			
-23	23	G	C	rs1115	GENE3	1E-08	0.3	0.1	4.1	0.4	0.1	chr23_23_G_C	chr23_23_G_C																						GENE3	non_coding_transcript_exon_variant
-23	230	C	G	rs1116	GENE3	1E-08	0.3	0.1	5.1	0.4	0.1	chr23_230_C_G	chr23_230_C_G																						GENE3	missense_variant
+1	1	A	G	rs1111	GENE1	0.1	0.1	0.1	0.1	0.2	0.1	chr1_1_A_G	chr1_1_A_G	0.07	0.09	0.1	0.11	0.12	0.13	0.6086956521739131	0.5833333333333335															
+1	10	T	C	rs1112	GENE1	0.1	0.1	0.1	1.1	0.2	0.1	chr1_10_T_C	chr1_10_T_C	0.17	0.19	0.2	0.21	0.22	0.23	0.7906976744186046	0.7727272727272728															
+4	4	C	T	rs1113	GENE2	1e-06	0.2	0.1	2.1	0.3	0.1	chr4_4_C_T	chr4_4_C_T									0.13	0.1	0.12	0.14	0.18	0.15	0.16	0.17	0.6410256410256411	0.625	0.6666666666666666	0.6521739130434783			
+4	40	G	A	rs1114	GENE2	1e-06	0.2	0.1	3.1	0.3	0.1	chr4_40_G_A	chr4_40_G_A									0.23	0.2	0.22	0.24	0.28	0.25	0.26	0.27	0.78125	0.7692307692307693	0.8	0.7894736842105263			
+23	23	G	C	rs1115	GENE3	1e-08	0.3	0.1	4.1	0.4	0.1	chr23_23_G_C	chr23_23_G_C																						GENE3	non_coding_transcript_exon_variant
+23	230	C	G	rs1116	GENE3	1e-08	0.3	0.1	5.1	0.4	0.1	chr23_230_C_G	chr23_230_C_G																						GENE3	missense_variant


### PR DESCRIPTION
The reason for this is that the nfe counts etc already contain the subpopulations, which changes the enrichment value, as some values are counted twice.