### PR TITLE
R5 wdls

### DIFF
--- a/wdl/autoreporting_completely_parallel_r4.json
+++ b/wdl/autoreporting_completely_parallel_r4.json
@@ -1,6 +1,6 @@
 {
     "autoreporting.input_array_file": "gs://r4_data_west1/autoreporting/r4_input_array_2020_03_17.tsv",
-    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:73436e",
+    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:e08570",
     "autoreporting.memory":20,
     "autoreporting.gnomad_exome":"gs://fg-datateam-analysisteam-share/gnomad/2.1/exomes/gnomad.exomes.r2.1.sites.liftover.b38.finngen.r2pos.af.ac.an.tsv.gz",
     "autoreporting.gnomad_genome":"gs://fg-datateam-analysisteam-share/gnomad/2.1/genomes/gnomad.genomes.r2.1.sites.liftover.b38.finngen.r2pos.af.ac.an.tsv.gz",

--- a/wdl/autoreporting_completely_parallel_r5.json
+++ b/wdl/autoreporting_completely_parallel_r5.json
@@ -1,6 +1,6 @@
 {
     "autoreporting.input_array_file": "gs://r5_data/autoreporting/r5_phenotype_array_2020_03_25.tsv",
-    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:73436e",
+    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:e08570",
     "autoreporting.memory":20,
     "autoreporting.gnomad_exome":"gs://fg-datateam-analysisteam-share/gnomad/2.1/exomes/gnomad.exomes.r2.1.sites.liftover.b38.finngen.r2pos.af.ac.an.tsv.gz",
     "autoreporting.gnomad_genome":"gs://fg-datateam-analysisteam-share/gnomad/2.1/genomes/gnomad.genomes.r2.1.sites.liftover.b38.finngen.r2pos.af.ac.an.tsv.gz",

--- a/wdl/autoreporting_serial_r4.json
+++ b/wdl/autoreporting_serial_r4.json
@@ -1,6 +1,6 @@
 {
     "autoreporting.input_array_file": "gs://r4_data_west1/autoreporting/r4_input_array_2020_03_17.tsv",
-    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:73436e",
+    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:e08570",
     "autoreporting.memory":20,
     "autoreporting.phenos_per_worker": 5,
     "autoreporting.cpus":4,

--- a/wdl/autoreporting_serial_r5.json
+++ b/wdl/autoreporting_serial_r5.json
@@ -1,6 +1,6 @@
 {
     "autoreporting.input_array_file": "gs://r5_data/autoreporting/r5_phenotype_array_2020_03_25.tsv",
-    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:73436e",
+    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:e08570",
     "autoreporting.memory":20,
     "autoreporting.phenos_per_worker": 8,
     "autoreporting.cpus":4,


### PR DESCRIPTION
Add r5 inputs to WDL. Update docker image to get rid of bug fixed in b5043969.