### PR TITLE
Fix bugs related to using other data & not having credible sets

### DIFF
--- a/Scripts/data_access/linkage.py
+++ b/Scripts/data_access/linkage.py
@@ -83,11 +83,14 @@ class PlinkLD(LDAccess):
             pr.wait()
             plink_log = pr.stdout.readlines()
             if pr.returncode != 0:
+                if any([ True for a in plink_log if "Error: No valid variants specified by --ld-snp/--ld-snps/--ld-snp-list." in a]):
+                    print("PLINK FAILURE. Variants not found in LD panel for chromosome {}".format(chrom))     
                 print("PLINK FAILURE. Error code {}".format(pr.returncode)  )
-                [print(l) for l in plink_log]
-                raise ValueError("Plink r2 calculation returned code {}".format(pr.returncode))
-            ld_data_=pd.read_csv("{}.ld".format(plink_prefix),sep="\s+")
-            ld_data=pd.concat([ld_data,ld_data_],axis="index",sort=False,ignore_index=True)
+                print(*plink_log, sep="\n")
+                #raise ValueError("Plink r2 calculation returned code {}".format(pr.returncode))
+            else:
+                ld_data_=pd.read_csv("{}.ld".format(plink_prefix),sep="\s+")
+                ld_data=pd.concat([ld_data,ld_data_],axis="index",sort=False,ignore_index=True)
             cleanup_cmd= "rm {}".format(plink_name)
             plink_files = glob.glob( "{}.*".format(plink_prefix) )
             subprocess.call(shlex.split(cleanup_cmd)+plink_files, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/Scripts/gws_fetch.py
+++ b/Scripts/gws_fetch.py
@@ -222,10 +222,11 @@ def fetch_gws(gws_fpath, sig_tresh_1,prefix,group,grouping_method,locus_width,si
     join_cols=[columns["chrom"], columns["pos"], columns["ref"], columns["alt"]]
     if cred_set_file != "":
         cs_df=load_credsets(cred_set_file,columns)
+        temp_df = merge_credset(temp_df,cs_df,gws_fpath,columns)
     else:
-        cs_df=pd.DataFrame(columns=join_cols+["cs_prob","cs_id"])
+        temp_df["cs_prob"]=np.nan
+        temp_df["cs_id"]=np.nan
     #merge with gws_df, by using chrom,pos,ref,alt
-    temp_df = merge_credset(temp_df,cs_df,gws_fpath,columns)
     #create necessary columns for the data
     temp_df=temp_df.reset_index(drop=True)
     temp_df.loc[:,"#variant"]=create_variant_column(temp_df,chrom=columns["chrom"],pos=columns["pos"],ref=columns["ref"],alt=columns["alt"])


### PR DESCRIPTION
1. Do not merge credible sets if they're not available
2. If PLINK fails due to missing snips (no snips in imputation panel), continue the script and print PLINK output to stdout