### PR TITLE
Issue #96 PR 3: Implement ratelimits for the ensembl API

### DIFF
--- a/Scripts/data_access/gwcatalog_api.py
+++ b/Scripts/data_access/gwcatalog_api.py
@@ -356,12 +356,12 @@ def in_chunks(lst, chunk_size):
 def parse_ensembl(json_data: Dict[str, Any]) -> List[Dict[str, Any]]:
     out=[]
     for rsid in json_data.keys():
-        alleles=json_data[rsid]["mappings"][0]["allele_string"].split("/")
-        first=alleles[0]
-        others = ";".join(alleles[1:])
+        alleles = json_data[rsid]["mappings"][0]["allele_string"].split("/")
+        reference = alleles[0]
+        alts = ";".join(alleles[1:])
         synonyms = json_data[rsid]["synonyms"]
-        biallelic= (len(alleles) == 2)
-        out.append({"rsid":rsid,"ref":first,"alt":others,"biallelic":biallelic,"synonyms":synonyms})
+        biallelic = (len(alleles) == 2)
+        out.append({"rsid":rsid,"ref":reference,"alt":alts,"biallelic":biallelic,"synonyms":synonyms})
     return out
 
 def get_rsid_alleles_ensembl(rsids: List[str]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Relevant issue: #96

This PR implements rate limits (or following the rate limits) for the ensembl REST API, as previously there have been problems with the API ratelimiting wdl workflows.

The ensembl API access is currently just a few functions, but could be refactored into its own class. I'd like input about that if possible.
