### PR TITLE
make WDL task fail if the run fails

### DIFF
--- a/wdl/autoreporting.wdl
+++ b/wdl/autoreporting.wdl
@@ -56,7 +56,7 @@ task report {
 
     command <<<
         python3 <<CODE
-        import subprocess, shlex
+        import subprocess, shlex, sys
         from subprocess import PIPE
         #do everything a wrapper should do
         #unchanged variables
@@ -185,6 +185,10 @@ task report {
         print("--- phenotype {} RETURN CODE: {} ---".format(pheno_id,pr.returncode))
         print("--- phenotype {} STDOUT ---".format(pheno_id))
         print(pr.stdout)
+        if pr.returncode != 0:
+            print("The report did not run successfully. Check the logs.")
+            print(phenoname,"exit code:",pr.returncode)
+            sys.exit(1)
         CODE
     >>>
 

--- a/wdl/report_serial.wdl
+++ b/wdl/report_serial.wdl
@@ -80,7 +80,7 @@ task report{
 
     command <<<
         python3 <<CODE
-        import subprocess, shlex, json
+        import subprocess, shlex, json, sys, itertools
         from subprocess import PIPE
         #do everything a wrapper should do
         #unchanged variables
@@ -125,7 +125,7 @@ task report{
             efos = {a.strip().split("\t")[0] : a.strip().split("\t")[1]  for a in f.readlines()}
         efo_array=["--efo-codes {}".format(efos[a]) if a in efos.keys() else "" for a in phenotypes ]
         
-
+        exit_codes = []
         for i in range(num_phenos):
             phenotype_name=phenotypes[i]
             call_command=("main.py {} "
@@ -205,6 +205,12 @@ task report{
             print("--- phenotype {} RETURN CODE: {} ---".format(phenotype_name,pr.returncode))
             print("--- phenotype {} STDOUT ---".format(phenotype_name))
             print(pr.stdout)
+            exit_codes.append(pr.returncode)
+        if any([a for a in exit_codes if a != 0]):
+            print("One or more of the reports did not run successfully. Check the logs.")
+            print("Exit codes:")
+            print(list(itertools.zip_longest(phenotypes, exit_codes) ) )
+            sys.exit(1)
         CODE
     >>>
     #output


### PR DESCRIPTION
Background: Currently, the WDL tasks for autoreporting runs do not fail if the autoreporting script fails. This is counter-intuitive, as it's better to show if the runs fail.

This PR fixes this - if the autoreporting run ends in an exception, the python wrapper in the WDL file notices this (by the processes return code) and notifies about that in the stdout, as well as returning 1, which makes the task count the run as failed.

This also works with the `report_serial` WDL, in its case if any of the autoreporting runs fail the task fails.