### PR TITLE
make PLINK get variant list without duplicates for LD calc

### DIFF
--- a/Scripts/data_access/linkage.py
+++ b/Scripts/data_access/linkage.py
@@ -65,6 +65,8 @@ class PlinkLD(LDAccess):
     def get_ranges(self, variants, window, ld_threshold = None):
         if not ld_threshold:
             ld_threshold = 0.0
+        #remove duplicates of variants, because PLINK errors with that
+        variants = variants.drop_duplicates(subset=["#variant"])
         #assume columns are: [chrom, pos, ref, alt,#variant], and window is int
         ld_data=pd.DataFrame()
         chromosomes = variants["chr"].unique()


### PR DESCRIPTION
Make PLINK always get non-duplicated list of variants, as it will error out if there are duplicated variants in the PLINK LD calculation input.