### PR TITLE
refactor LD API interface

### DIFF
--- a/Scripts/data_access/db.py
+++ b/Scripts/data_access/db.py
@@ -17,7 +17,7 @@ class ExtDB(object):
             regions (List[Dict[str, Any]]): The list of regions for which associations are queried
         """
 
-class LDInput(NamedTuple):
+class Variant(NamedTuple):
     """Variant class for LDAccess api
         variant: str
         chrom: str
@@ -30,29 +30,38 @@ class LDInput(NamedTuple):
     pos: int
     ref: str
     alt: str
-
     def __eq__(self, other): 
-        if not isinstance(other, LDInput):
+        if not isinstance(other, Variant):
             return NotImplemented
         return self.variant == other.variant
 
 class LDData(NamedTuple):
     """LD information class for LDAccess api
-        variant1: str
-        variant2: str
-        chrom1: str
-        chrom2: str
-        pos1: int
-        pos2: int
+        variant1: Variant
+        variant2: Variant
         r2: float
     """
-    variant1: str
-    variant2: str
-    chrom1: str
-    chrom2: str
-    pos1: int
-    pos2: int
+    variant1: Variant
+    variant2: Variant
     r2: float
+    def to_flat(self) -> Dict[str,Any]:
+        """Helper method to flatten LDData
+        Returns:
+            Dict[str,Any]: Dictionary with keys (variant1,chrom1,pos1,ref1,alt1,variant2,chrom2,pos2,ref2,alt2,r2)
+        """
+        return {
+            "variant1":self.variant1.variant,
+            "chrom1":self.variant1.chrom,
+            "pos1":self.variant1.pos,
+            "ref1":self.variant1.ref,
+            "alt1":self.variant1.alt,
+            "variant2":self.variant2.variant,
+            "chrom2":self.variant2.chrom,
+            "pos2":self.variant2.pos,
+            "ref2":self.variant2.ref,
+            "alt2":self.variant2.alt,
+            "r2":self.r2
+        }
 
 class LDAccess(object):
     """
@@ -60,7 +69,7 @@ class LDAccess(object):
     """
 
     @abc.abstractmethod
-    def get_ranges(self, variants: List[LDInput], window: int, ld_threshold: Optional[float]) -> List[LDData]:
+    def get_ranges(self, variants: List[Variant], window: int, ld_threshold: Optional[float]) -> List[LDData]:
         """Return LD for multiple variant ranges
         Args: variant data, i.e. a dataframe with columns [chr, pos, ref, alt, #variant], a window,ld threshold
             variants (List[LDInput]): List of input variants ()

--- a/testing/test_fetch.py
+++ b/testing/test_fetch.py
@@ -7,7 +7,7 @@ sys.path.insert(0, './Scripts')
 import pandas as pd,numpy as np
 from Scripts import gws_fetch
 from Scripts import autoreporting_utils as autils
-from Scripts.data_access.db import LDData
+from Scripts.data_access.db import LDData, Variant
 from io import StringIO
 
 class Arg():
@@ -90,13 +90,17 @@ class TestGws(unittest.TestCase):
         prefix=""
         r2_out = pd.read_csv("testing/fetch_resources/ld_grouping_report.csv",sep="\t")
         r2_out = r2_out.to_dict('records')
-        r2_out = [LDData(variant1=a['variant_1'],
-                         variant2=a['variant_2'],
-                         chrom1=a['chrom_1'],
-                         chrom2=a['chrom_2'],
-                         pos1=a['pos_1'],
-                         pos2=a['pos_2'],
-                         r2=a['r2']) for a in r2_out]
+        r2_out = [LDData(Variant(a['variant_1'],
+                                 a['chrom_1'],
+                                 a['pos_1'],
+                                 a['variant_1'].split("_")[2],
+                                 a['variant_1'].split("_")[3]),
+                         Variant(a['variant_2'],
+                                 a['chrom_2'],
+                                 a['pos_2'],
+                                 a['variant_2'].split("_")[2],
+                                 a['variant_2'].split("_")[3]),
+                         a['r2']) for a in r2_out]
         #1
         class AugmentedMock(mock.Mock):
             def get_ranges(*args):
@@ -182,13 +186,17 @@ class TestGws(unittest.TestCase):
         data.loc[9,"cs_prob"] = 0.997
         r2_out=pd.read_csv("testing/fetch_resources/ld_report.csv",sep="\t")
         r2_out = r2_out.to_dict('records')
-        r2_out = [LDData(variant1=a['variant_1'],
-                         variant2=a['variant_2'],
-                         chrom1=a['chrom_1'],
-                         chrom2=a['chrom_2'],
-                         pos1=a['pos_1'],
-                         pos2=a['pos_2'],
-                         r2=a['r2']) for a in r2_out]
+        r2_out = [LDData(Variant(a['variant_1'],
+                                 a['chrom_1'],
+                                 a['pos_1'],
+                                 a['variant_1'].split("_")[2],
+                                 a['variant_1'].split("_")[3]),
+                         Variant(a['variant_2'],
+                                 a['chrom_2'],
+                                 a['pos_2'],
+                                 a['variant_1'].split("_")[2],
+                                 a['variant_1'].split("_")[3]),
+                         a['r2']) for a in r2_out]
         class AugmentedMock(mock.Mock):
             def get_ranges(*args):
                 return r2_out


### PR DESCRIPTION
Refactor the LD API to use collections of specific objects created for storing LD information and relevant variant information, instead of using opaque dataframes as input and output arguments. The objects are based on `NamedTuple`. 

The actual LD information comes from PLINK or ld_server, which is why there are two different implementations.

The reason for this PR was to make the LD API easier to use.