### PR TITLE
N ld partners

### DIFF
--- a/Scripts/top_report.py
+++ b/Scripts/top_report.py
@@ -61,7 +61,7 @@ def create_top_level_report(report_df,efo_traits,columns,grouping_method,signifi
     aggregated_cols = ["credible_set_min_r2_value","start", "end", "found_associations_strict", "found_associations_relaxed",
                        "credible_set_variants", "functional_variants_strict",
                        "functional_variants_relaxed", "specific_efo_trait_associations_strict",
-                       "specific_efo_trait_associations_relaxed","n_ld_partners_0_8"]
+                       "specific_efo_trait_associations_relaxed","n_ld_partners_0_8","n_ld_partners_0_6"]
 
     lead_cols=list(lead_col_d.values())
     gnomad_cols = list(gnomad_add_cols_rename.values())
@@ -199,10 +199,13 @@ def create_top_level_report(report_df,efo_traits,columns,grouping_method,signifi
         except:
             row["credible_set_min_r2_value"] = np.nan
 
-        #N ld partners with LD >0.8
+        #N ld partners with LD >0.8, LD>0.6
         r2_thresh_0_8 = 0.8
-        n_ld_gt_0_8 = loc_variants[((loc_variants["r2_to_lead"]>r2_thresh_0_8) & (loc_variants["cs_id"]!=locus_cs_id)),"r2_to_lead"].count()
+        r2_thresh_0_6 = 0.6
+        n_ld_gt_0_8 = loc_variants.loc[((loc_variants["r2_to_lead"]>r2_thresh_0_8) & (loc_variants["cs_id"]!=locus_cs_id)),"r2_to_lead"].count()
+        n_ld_gt_0_6 = loc_variants.loc[((loc_variants["r2_to_lead"]>r2_thresh_0_6) & (loc_variants["cs_id"]!=locus_cs_id)),"r2_to_lead"].count()
         row["n_ld_partners_0_8"] = n_ld_gt_0_8
+        row["n_ld_partners_0_6"] = n_ld_gt_0_6
         top_level_df=top_level_df.append(row,ignore_index=True)
 
     #merge the different dataframes to top_level_df


### PR DESCRIPTION
Related to #169 

This PR adds two columns, n_ld_partners_0_8 and n_ld_partners_0_6 into the top report, which report the amount of LD partners that a group has, which have LD >0.8 and 0.6, respectively. CS variants are NOT counted in that number.

WDL not changed as the changes do not change anything there.