### PR TITLE
Fix for missing phenotype info file

### DIFF
--- a/wdl/autoreporting.wdl
+++ b/wdl/autoreporting.wdl
@@ -93,7 +93,7 @@ task report {
         custom_dataresource="${custom_dataresource}"
         column_names = "${sep=" " column_names}"
         extra_columns = "${extra_columns}"
-        phenotype_info = "${phenotype_info_file}"
+        phenotype_info = "--pheno-info-file ${phenotype_info_file}" if "${phenotype_info_file}" != empty_file else "" 
 
         alleledb_file = "${allele_vcf_file}"
 
@@ -138,7 +138,7 @@ task report {
                     "--db {} "
                     "--column-labels {} "
                     "--extra-cols {} "
-                    "--pheno-info-file {} "
+                    "{} " #phenofile
                     "--gwascatalog-allele-file {} "
                     "{} " #local gwascatalog
                     "{} " #efo


### PR DESCRIPTION
If phenotype info file is missing (set as "gs://misc-analysis/EMPTY_FILE" in the json), the missing output is not handled correctly and the empty file is read causing `pandas.errors.EmptyDataError`.

This PR fixes that by handling the empty file same as is done elsewhere in the wdl.