### PR TITLE
fix 404 returning none

### DIFF
--- a/Scripts/data_access/linkage.py
+++ b/Scripts/data_access/linkage.py
@@ -24,11 +24,11 @@ class OnlineLD(LDAccess):
             data=try_request("GET",url=self.url,params=params)
         except ResourceNotFound as e:
             print("LD data not found (status code {}) with url {} and params {}.".format(e.parameters["status_code"],self.url,params) )
-            return LDData(
+            return [LDData(
                 Variant(chrom,pos,ref,alt),
                 Variant(chrom,pos,ref,alt),
                 1.0
-            )
+            )]
         except ResponseFailure as e:
             print("Error with request.")
             print(e)


### PR DESCRIPTION
fixel ld online api behaving incorrectly when presented with a variant that does not exist in the ld server's data.
Now returns [LDData(var,var,1.0)] instead of None