### PR TITLE
Fix region pruning: Change from dict to Region, fix algorithm

### DIFF
--- a/Scripts/compare.py
+++ b/Scripts/compare.py
@@ -191,7 +191,10 @@ def compare(df, ld_check, plink_mem, ld_panel_path,
         summary_df = pd.read_csv("{}gwas_out_mapping.tsv".format(prefix),sep="\t")
     else:
         range_df = df.loc[:,[columns["chrom"],"pos_rmin","pos_rmax"]].drop_duplicates().copy(deep=True)
-        regions = prune_regions(range_df).to_dict("records")
+        regions = [
+            Region(a[columns["chrom"]],int(a["pos_rmin"]),int(a["pos_rmax"])) for i,a in range_df.iterrows()
+        ]
+        regions = prune_regions(regions)
         assoc_records = association_db.associations_for_regions(regions)
         assoc_df = pd.DataFrame(assoc_records)
         if not assoc_df.empty:

--- a/Scripts/data_access/custom_catalog.py
+++ b/Scripts/data_access/custom_catalog.py
@@ -2,6 +2,7 @@ import abc
 from typing import List, Text, Dict,Any
 import pandas as pd, numpy as np
 from data_access.db import ExtDB
+from autoreporting_utils import Region
 
 class CustomCatalog(ExtDB):
     def __init__(self, fname: str, pval_threshold: float, padding: int):
@@ -35,13 +36,13 @@ class CustomCatalog(ExtDB):
         """
         return trait_code
     
-    def associations_for_regions(self, regions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def associations_for_regions(self, regions: List[Region]) -> List[Dict[str, Any]]:
         """Return associations for a list of regions of type {"chrom": str, "min": int, "max": int }
         Args:
             regions (List[Dict[str, Any]]): The list of regions for which associations are queried
         """
         out= []
         for region in regions:
-            assocs=self.__get_associations(region["chrom"],region["min"],region["max"])
+            assocs=self.__get_associations(region.chrom,region.start,region.end)
             out.extend(assocs)
         return out

--- a/Scripts/data_access/db.py
+++ b/Scripts/data_access/db.py
@@ -5,16 +5,17 @@ import abc
 from typing import List, Text, Dict,Any, Optional, NamedTuple
 from io import StringIO
 import pandas as pd #type: ignore
+from autoreporting_utils import Region
 
 class ExtDB(object):
     """Abstract base class for association searches
     """
 
     @abc.abstractmethod
-    def associations_for_regions(self, regions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Return associations for a list of regions of type {"chrom": str, "min": int, "max": int }
+    def associations_for_regions(self, regions: List[Region]) -> List[Dict[str, Any]]:
+        """Return associations for a list of regions
         Args:
-            regions (List[Dict[str, Any]]): The list of regions for which associations are queried
+            regions (List[Region]): The list of regions for which associations are queried
         """
 
 class Variant(NamedTuple):

--- a/testing/test_gwcat.py
+++ b/testing/test_gwcat.py
@@ -8,6 +8,7 @@ sys.path.append("./")
 sys.path.insert(0, './Scripts')
 from Scripts.data_access import gwcatalog_api
 from Scripts.data_access.db import AlleleDB, Location, VariantData, Variant
+from Scripts.autoreporting_utils import Region
 import itertools
 from io import StringIO
 
@@ -295,9 +296,9 @@ class TestLocalDB(unittest.TestCase):
         alldb = MockAlleleDB()
         db = gwcatalog_api.LocalDB(buf,1.0,100,alldb)
         regions = [
-            {"chrom":"1","min":1,"max":2},
-            {"chrom":"2","min":10,"max":12},
-            {"chrom":"3","min":100,"max":102},
+            Region("1",1,2),
+            Region("2",10,12),
+            Region("3",100,102)
         ]
         assocs = db.associations_for_regions(regions)
         validationdata = [{
@@ -326,9 +327,9 @@ class testGWASDB(unittest.TestCase):
         mockdb = MockAlleleDB()
         db = gwcatalog_api.GwasApi(1.0,100,1,mockdb)
         ranges = [
-            {"chrom":"1","min":1,"max":2},
-            {"chrom":"2","min":10,"max":12},
-            {"chrom":"3","min":100,"max":102},
+            Region("1",1,2),
+            Region("2",10,12),
+            Region("3",100,102)
         ]
         
         request_val = mock.Mock() 

--- a/testing/test_utils.py
+++ b/testing/test_utils.py
@@ -4,6 +4,7 @@ sys.path.append("../")
 sys.path.append("./")
 import pandas as pd,numpy as np
 from Scripts import autoreporting_utils
+from Scripts.autoreporting_utils import Region
 
 class TestUtils(unittest.TestCase):
     def test_create_variant_column(self):
@@ -16,46 +17,59 @@ class TestUtils(unittest.TestCase):
 
     def test_region_pruning(self):
         #case no regions
-        reg=pd.DataFrame([])
-        df=pd.DataFrame(columns=["#chrom", "pos_rmax","pos_rmin"])
-        reg2=autoreporting_utils.prune_regions(df)
-        #value=(reg==reg2).all().all()
-        self.assertTrue(reg.equals(reg2))
+        reg=[]
+        out=[]
+        reg2=autoreporting_utils.prune_regions(reg)
+        self.assertEqual(reg,reg2)
         #case one region
-        reg=pd.DataFrame({"chrom":"1","min":10,"max":20},index=[0])
-        df=pd.DataFrame({"#chrom":"1", "pos_rmin":10,"pos_rmax":20},index=[0])
-        reg2=autoreporting_utils.prune_regions(df)
-        self.assertTrue(reg.equals(reg2))
+        reg=[Region("1",10,20)]
+        reg2=autoreporting_utils.prune_regions(reg)
+        self.assertEqual(reg,reg2)
         #case two regions: no overlap by position
-        reg=pd.DataFrame({"chrom":["1","1"],"min":[10,30],"max":[20,40] })
-        df=pd.DataFrame({"#chrom":["1","1"],"pos_rmax":[20,40],"pos_rmin":[10,30]})
-        reg2=autoreporting_utils.prune_regions(df)
-        self.assertTrue(reg.equals(reg2))
+        regs = [Region("1",10,20),Region("1",30,40)]
+        reg2=autoreporting_utils.prune_regions(regs)
+        self.assertEqual(regs,reg2)
         #case two regions: overlapping positions, different chromosomes
-        reg=pd.DataFrame({"chrom":["1","2"],"min":[10,20],"max":[40,30] })
-        df=pd.DataFrame({"#chrom":["1","2"],"pos_rmax":[40,30],"pos_rmin":[10,20]})
-        reg2=autoreporting_utils.prune_regions(df)
-        self.assertTrue(reg.equals(reg2))
+        regs = [Region("1",10,40),Region("2",20,30)]
+        reg2=autoreporting_utils.prune_regions(regs)
+        self.assertEqual(regs,reg2)
         #case two regions: one in other, i.e. 1_min 2_min 2_max 1_max
-        reg=pd.DataFrame({"chrom":["1"],"min":[10],"max":[40] })
-        df=pd.DataFrame({"#chrom":["1","1"],"pos_rmax":[40,20],"pos_rmin":[10,30]})
-        reg2=autoreporting_utils.prune_regions(df)
-        self.assertTrue(reg.equals(reg2))
+        validate=[Region("1",10,40)]
+        regs=[Region("1",10,40),Region("1",20,30)]
+        reg2=autoreporting_utils.prune_regions(regs)
+        self.assertEqual(validate,reg2)
         #case two regions: 1_min 2_min 1_max 2_max
-        reg=pd.DataFrame({"chrom":["1"],"min":[10],"max":[40] })
-        df=pd.DataFrame({"#chrom":["1","1"],"pos_rmax":[30,40],"pos_rmin":[10,15]})
-        reg2=autoreporting_utils.prune_regions(df)
-        self.assertTrue(reg.equals(reg2))
+        validate = [Region("1",10,40)]
+        regs=[Region("1",10,30), Region("1",15,40)]
+        reg2=autoreporting_utils.prune_regions(regs)
+        self.assertEqual(validate,reg2)
         #case two regions: 2_min 1_min 2_max 1_max
-        reg=pd.DataFrame({"chrom":["1"],"min":[10],"max":[40] })
-        df=pd.DataFrame({"#chrom":["1","1"],"pos_rmax":[30,40],"pos_rmin":[10,15]})
-        reg2=autoreporting_utils.prune_regions(df)
-        self.assertTrue(reg.equals(reg2))
+        validate = [Region("1",10,40)]
+        regs = [Region("1",15,40), Region("1",10,30)]
+        reg2=autoreporting_utils.prune_regions(regs)
+        self.assertEqual(reg2, validate)
         #case two regions: 2_min 1_min 1_max 2_max
-        reg=pd.DataFrame({"chrom":["1"],"min":[10],"max":[40] })
+        validate = [Region("1",10,40)]
+        regs=[Region("1",15,30), Region("1",10,40)]
         df=pd.DataFrame({"#chrom":["1","1"],"pos_rmax":[30,40],"pos_rmin":[15,10]})
-        reg2=autoreporting_utils.prune_regions(df)
-        self.assertTrue(reg.equals(reg2))
+        reg2=autoreporting_utils.prune_regions(regs)
+        self.assertEqual(reg2, validate)
+        #6 regions, with 3 output regions
+        regions=[
+            Region("1",1,100),
+            Region("1",75,150),
+            Region("1",100,200),
+            Region("1",250,251),
+            Region("1",251,260),
+            Region("1",300,305),
+        ]
+        validation=[
+            Region("1",1,200),
+            Region("1",250,260),
+            Region("1",300,305)
+        ]
+        out=autoreporting_utils.prune_regions(regions)
+        self.assertEqual(set(validation),set(out))
 
     #TODO: test get gzip header
 


### PR DESCRIPTION
Originally, I started working on this because in compare.py this was called with the chrom column of the data , chich is not usually "#chrom". I changed the input type to be a namedtuple, so I can't do the same mistake again - The type conversion needs to be done for things to work. 

I also changed the algorithm from one that merely decreases the amount of regions into an optimal one, which results in no overlapping regions.