### PR TITLE
fix GWAS summary without header in tabix

### DIFF
--- a/Scripts/autoreporting_utils.py
+++ b/Scripts/autoreporting_utils.py
@@ -3,6 +3,7 @@ from subprocess import Popen, PIPE
 import pandas as pd, numpy as np #typing: ignore
 import pysam
 from typing import List, Dict, NamedTuple
+import gzip
 """
 Utility functions that are used in the scripts, put here for keeping the code clearer
 """
@@ -85,7 +86,12 @@ def load_pysam_df(df,fpath,columns,chrom_prefix="",na_value=".") -> pd.DataFrame
             rows = []
         data = [a.strip('\n').split('\t') for a in rows]
         tbxlst.extend(data)
-    header = tb.header[0].split('\t')
+
+    #header = tb.header[0].split('\t')
+    with gzip.open(fpath) as f:
+        header_temp = f.readline().decode()
+    header = header_temp.strip("\n").split("\t")
+ 
     out_df = pd.DataFrame(tbxlst, columns = header)
     out_df=out_df.replace(na_value,np.nan)
     out_df[out_df.columns]=out_df[out_df.columns].apply(pd.to_numeric,errors="ignore")
@@ -102,7 +108,10 @@ def load_pysam_ranges(df: pd.DataFrame, fpath: str, chrom_prefix: str = "", na_v
             rows = []
         data = [a.strip('\n').split('\t') for a in rows]
         tbxlst.extend(data)
-    header = tb.header[0].split('\t')
+    #header = tb.header[0].split('\t')
+    with gzip.open(fpath) as f:
+        header_temp = f.readline().decode()
+    header = header_temp.strip("\n").split("\t")
     out_df = pd.DataFrame(tbxlst, columns = header)
     out_df=out_df.replace(na_value,np.nan)
     out_df[out_df.columns]=out_df[out_df.columns].apply(pd.to_numeric,errors="ignore")

--- a/Scripts/gws_fetch.py
+++ b/Scripts/gws_fetch.py
@@ -352,6 +352,9 @@ def fetch_gws(gws_fpath: str,
         summ_stat_variants = summ_stat_variants_x if summ_stat_variants_x.shape[0] > summ_stat_variants_23.shape[0] else summ_stat_variants_23
         summ_stat_variants = df_replace_value(summ_stat_variants,columns["chrom"],"X","23")#finally in chrom 23 
         
+        # fix if there are some NA values
+        summ_stat_variants[columns["pval"]] = pd.to_numeric(summ_stat_variants[columns["pval"]], errors="coerce")
+        
         #filter them by p-value threshold 2. Merge credset will take care of cs variants that are filtered out.
         summ_stat_variants= summ_stat_variants.loc[summ_stat_variants[columns["pval"]]<=sig_tresh_2,:]
         


### PR DESCRIPTION
Fix an issue when the summary statistics is not start with "#", hence the header is not in the tabix index. The change works universal in any cases. 