### PR TITLE
filter variants without pval, betas from summary statistic files

### DIFF
--- a/Scripts/group_annotation.py
+++ b/Scripts/group_annotation.py
@@ -120,8 +120,8 @@ class PreviousReleaseAnnotation(TabixAnnotation):
 
     def _create_annotation(self,cols:List[str],hdi:Dict[str,int])->Annotation:
         #get pval and beta
-        pval = float(cols[hdi[self.pval_col]])
-        beta = float(cols[hdi[self.beta_col]])
+        pval = tryfloat(cols[hdi[self.pval_col]])
+        beta = tryfloat(cols[hdi[self.beta_col]])
         return [{"pval_previous_release":pval,"beta_previous_release":beta}]
 
     @staticmethod


### PR DESCRIPTION
Issue: If the summary statistic contained variants with NA pval, beta, the script would crash.
Now, instead those variants will be filtered.
Also previous release annotation will now insert nan if can't parse pval , beta