### PR TITLE
Speed up simple and LD grouping

### DIFF
--- a/Scripts/group_annotation.py
+++ b/Scripts/group_annotation.py
@@ -71,7 +71,7 @@ class TabixAnnotation(AnnotationSource):
         if len(variants) > self.variant_switch:
             #figure out chroms,starts,ends for each one region in chromosome
             chr_d = generate_chrom_ranges(variants)
-            chr_v_sets:Dict[str,set[Variant]] = {set() for _ in chr_d.keys()}
+            chr_v_sets:Dict[str,set[Variant]] = {key:set() for key in chr_d.keys()}
             for v in variants:
                 chr_v_sets[v.chrom].add(v)
             if any([a not in self.sequences for a in chr_d.keys()]):

--- a/Scripts/grouping_model.py
+++ b/Scripts/grouping_model.py
@@ -61,7 +61,7 @@ class LocusVariants(NamedTuple):
 class Locus:
 
     @abc.abstractmethod
-    def variants(self) -> List[Variant]:
+    def variants(self) -> set[Variant]:
         pass
 
     @abc.abstractmethod
@@ -98,7 +98,7 @@ class CSLocus(Locus):
     def add_ld_partners(self, ld_partners:List[Var]):
         self.ld_partners = ld_partners
     
-    def variants(self) -> List[Variant]:
+    def variants(self) -> set[Variant]:
         output = set()
         output.add(self.lead.id)
         for v in self.cs:
@@ -106,7 +106,7 @@ class CSLocus(Locus):
         if self.ld_partners:
             for v in self.ld_partners:
                 output.add(v.id)
-        return list(output)
+        return output
 
     def type(self)->Grouping:
         return Grouping.CS
@@ -123,13 +123,13 @@ class PeakLocus(Locus):
         self.ld_partners = ld_partners
         self.locus_type = locus_type
     
-    def variants(self)->List[Variant]:
+    def variants(self)->set[Variant]:
         output = set()
         output.add(self.lead.id)
         if self.ld_partners:
             for v in self.ld_partners:
                 output.add(v.id)
-        return list(output)
+        return output
 
     def get_vars(self):
         return LocusVariants(self.lead,None,self.ld_partners)
@@ -152,12 +152,9 @@ class PhenoData:
         self.annotations: Dict[str,Dict[Variant,Annotation]] = {}
     
     @timefunc
-    def get_variants(self)->List[Variant]:
-        
-        out:set[Variant] = set()
-        for l in self.loci:
-            out = out.union(l.variants())
-        return sorted(list(out),key=cmp_to_key(_varcmp))
+    def get_variants(self)->set[Variant]:
+        loci = [l.variants() for l in self.loci]
+        return set().union(*loci)
 
     def add_annotation(self,annotation_name,annotation:Dict[Variant,Annotation]):
         self.annotations[annotation_name]=annotation

--- a/Scripts/grouping_model.py
+++ b/Scripts/grouping_model.py
@@ -4,6 +4,7 @@ from data_access.db import Variant, CS
 from enum import Enum, unique
 import abc
 from functools import cmp_to_key
+from time_decorator import timefunc
 
 @unique
 class Grouping(Enum):
@@ -149,7 +150,8 @@ class PhenoData:
         self.phenoinfo = phenoinfo
         self.loci = loci
         self.annotations: Dict[str,Dict[Variant,Annotation]] = {}
-
+    
+    @timefunc
     def get_variants(self)->List[Variant]:
         
         out:set[Variant] = set()

--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -9,6 +9,7 @@ from phenoinfo import get_phenotype_data, PhenoInfoOptions
 from load_tabix import tb_resource_manager,TabixOptions
 from data_access.csfactory import csfactory
 from typing import Optional, List
+import os
 
 
 def groupingModeFactory(method:str,group:bool):
@@ -165,10 +166,17 @@ def main(args):
         ### annotate
         phenodata = annotate(phenodata,annotation_resources)
         ### create report
-        with open(args.report_out,"w") as report_file, open(args.top_report_out,"w") as top_file:
+
+        report_fname = create_fname(args.report_out)
+        top_fname = create_fname(args.top_report_out)
+        with open(report_fname,"w") as report_file, open(top_fname,"w") as top_file:
             generate_variant_report(phenodata,report_file,variant_report_options)
             generate_top_report(phenodata,top_file,top_report_options)
     
+
+def create_fname(path:str,prefix:str)->str:
+    head,tail = os.path.split(path)
+    return os.path.join(head,f"{prefix}{tail}")
 
 if __name__=="__main__":
     parser=argparse.ArgumentParser(description="FINNGEN automatic hit reporting tool")

--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -167,8 +167,8 @@ def main(args):
         phenodata = annotate(phenodata,annotation_resources)
         ### create report
 
-        report_fname = create_fname(args.report_out)
-        top_fname = create_fname(args.top_report_out)
+        report_fname = create_fname(args.report_out,args.prefix)
+        top_fname = create_fname(args.top_report_out,args.prefix)
         with open(report_fname,"w") as report_file, open(top_fname,"w") as top_file:
             generate_variant_report(phenodata,report_file,variant_report_options)
             generate_top_report(phenodata,top_file,top_report_options)


### PR DESCRIPTION
An user noticed that the grouping functions for simple and LD grouping were a bit too inefficient. 
An easy speedup is to separate grouping by chromosome, which will lower the amount of variants grouped at a time, and this will result in a speedup on any function with a superlinear time complexity. See #214 for information.
This PR implements the speedup in #214 and fixes a bug with the prefix not being included in output filenames, and adds timing to getting all variants of a phenoresult.