### PR TITLE
Add max pip coding variants into group report

### DIFF
--- a/Scripts/group_annotation.py
+++ b/Scripts/group_annotation.py
@@ -343,7 +343,7 @@ class FGAnnotation(TabixAnnotation):
         rsid = cols[hdi[self.colnames["rsids"]]]
         infocol_names = [a for a in hdi.keys() if a.startswith("INFO_")]
         infocol_values = [tryfloat(cols[hdi[a]]) for a in infocol_names]
-        n_info_gt_0_6 = len([a for a in infocol_values if a > 0.6])/len(infocol_values)
+        n_info_gt_0_6 = len([a for a in infocol_values if a > 0.6])/max(len(infocol_values),1 )
         return [{
             self.out_columns[0]:most_severe_gene,
             self.out_columns[1]:most_severe_consequence,

--- a/Scripts/group_annotation.py
+++ b/Scripts/group_annotation.py
@@ -325,13 +325,15 @@ class FGAnnotation(TabixAnnotation):
             "FG_INFO",
             "n_INFO_gt_0_6",
             "functional_category",
-            "rsids"
+            "rsids",
+            "FG_AF"
         ]
         self.colnames = {
             "most_severe_gene":"gene_most_severe",
             "most_severe_consequence":"most_severe",
             "FG_INFO":"INFO",
-            "rsids":"rsid"
+            "rsids":"rsid",
+            "FG_AF":"AF"
         }
         self.variant_switch = 1_000_000
 
@@ -341,6 +343,7 @@ class FGAnnotation(TabixAnnotation):
         functional_category = cols[hdi[self.colnames["most_severe_consequence"]]] if cols[hdi[self.colnames["most_severe_consequence"]]] in FUNCTIONAL_CATEGORIES else "NA"
         fg_info = cols[hdi[self.colnames["FG_INFO"]]]
         rsid = cols[hdi[self.colnames["rsids"]]]
+        fg_af = cols[hdi[self.colnames["FG_AF"]]]
         infocol_names = [a for a in hdi.keys() if a.startswith("INFO_")]
         infocol_values = [tryfloat(cols[hdi[a]]) for a in infocol_names]
         n_info_gt_0_6 = len([a for a in infocol_values if a > 0.6])/max(len(infocol_values),1 )
@@ -350,7 +353,8 @@ class FGAnnotation(TabixAnnotation):
             self.out_columns[2]:fg_info,
             self.out_columns[3]:n_info_gt_0_6,
             self.out_columns[4]:functional_category,
-            self.out_columns[5]:rsid
+            self.out_columns[5]:rsid,
+            self.out_columns[6]:fg_af
         }]
 
     @staticmethod
@@ -364,7 +368,8 @@ class FGAnnotation(TabixAnnotation):
             "FG_INFO",
             "n_INFO_gt_0_6",
             "functional_category",
-            "rsids"
+            "rsids",
+            "FG_AF"
         ]
 
 def calculate_enrichment(nfe_AC:List[int],nfe_AN:List[int],fi_af:float):

--- a/Scripts/grouping_report.py
+++ b/Scripts/grouping_report.py
@@ -478,7 +478,7 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions)
                 # get all cs variant pips
                 coding_vars = [a for a in cs_vars_2 if fg_ann.get(a.id,[{"functional_category":"NA"}])[0]["functional_category"]!="NA"]
                 if coding_vars:
-                    max_pip_coding_var = max([(a,cs_ann[a.id]["prob"]) for a in coding_vars],key=lambda x:x[1])[0]                    
+                    max_pip_coding_var = max([(a,cs_ann[a.id][0]["prob"]) for a in coding_vars],key=lambda x:x[1])[0]
                     #if extra col
                     # most severe gene and consequence
                     max_pip_coding_var_fg_ann = fg_ann[max_pip_coding_var.id][0]

--- a/Scripts/grouping_report.py
+++ b/Scripts/grouping_report.py
@@ -299,6 +299,7 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions)
         "best_coding_var_consequence",
         "best_coding_var_gene",
         "best_coding_var_af",
+        "best_coding_var_eur_af",
         "best_coding_var_beta",
         "best_coding_var_p",
         "found_associations_strict",
@@ -465,13 +466,13 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions)
         if options.grouping_method==Grouping.CS and \
         FGAnnotation.get_name() in data.annotations and \
         CSAnnotation.get_name() in data.annotations and \
-        ExtraColAnnotation.get_name() in data.annotations:
+        Gnomad4Annotation.get_name() in data.annotations:
             try:
                 fg_ann = data.annotations[FGAnnotation.get_name()]
                 cs_ann = data.annotations[CSAnnotation.get_name()]
-                extra_ann = data.annotations[ExtraColAnnotation.get_name()]
+                gnomad_ann = data.annotations[Gnomad4Annotation.get_name()]
             except Exception as e:
-                print("Error on creating best coding var in group report: One or more of the data resources not available!")
+                print(f"Error on creating best coding var in group report: One or more of the data resources not available! Looked for {[FGAnnotation.get_name(),CSAnnotation.get_name(),Gnomad4Annotation.get_name()]}")
                 raise e
             try:
                 cs_vars_2 = list(set(cs_vars+[lead]))
@@ -482,11 +483,12 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions)
                     #if extra col
                     # most severe gene and consequence
                     max_pip_coding_var_fg_ann = fg_ann[max_pip_coding_var.id][0]
-                    max_pip_coding_var_extra_ann = extra_ann.get(max_pip_coding_var.id,[{}])[0]
+                    max_pip_coding_var_gnomad_ann = gnomad_ann.get(max_pip_coding_var.id,[{}])[0]
                     cols["best_coding_var"] = max_pip_coding_var.id
                     cols["best_coding_var_consequence"] = max_pip_coding_var_fg_ann["most_severe_consequence"]
                     cols["best_coding_var_gene"] = max_pip_coding_var_fg_ann["most_severe_gene"]
-                    cols["best_coding_var_af"] = max_pip_coding_var_extra_ann.get("af_alt","NA")
+                    cols["best_coding_var_af"] = max_pip_coding_var_fg_ann.get("FG_AF","NA")
+                    cols["best_coding_var_eur_af"] = max_pip_coding_var_gnomad_ann.get("GNOMAD_AF_nfe","NA")
                     cols["best_coding_var_beta"] = max_pip_coding_var.beta
                     cols["best_coding_var_p"] = max_pip_coding_var.pval
             except Exception as e:

--- a/Scripts/grouping_report.py
+++ b/Scripts/grouping_report.py
@@ -295,6 +295,12 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions)
         "credible_set_min_r2_value",
         "start",
         "end",
+        "best_coding_var",
+        "best_coding_var_consequence",
+        "best_coding_var_gene",
+        "best_coding_var_af",
+        "best_coding_var_beta",
+        "best_coding_var_p",
         "found_associations_strict",
         "found_associations_relaxed",
         "credible_set_variants",
@@ -455,7 +461,36 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions)
                 cols["credible_set_variants"] = ";".join([f"{get_varid(a[0].id)}|{a[1]:.3g}|{a[0].r2_to_lead:.3g}" for a in sorted_cs_vars])
             except Exception as e:
                 raise Exception("Error: bug",e)
-        
+        # best coding var in credset
+        if options.grouping_method==Grouping.CS and \
+        FGAnnotation.get_name() in data.annotations and \
+        CSAnnotation.get_name() in data.annotations and \
+        ExtraColAnnotation.get_name() in data.annotations:
+            try:
+                fg_ann = data.annotations[FGAnnotation.get_name()]
+                cs_ann = data.annotations[CSAnnotation.get_name()]
+                extra_ann = data.annotations[ExtraColAnnotation.get_name()]
+            except Exception as e:
+                print("Error on creating best coding var in group report: One or more of the data resources not available!")
+                raise e
+            try:
+                cs_vars_2 = list(set(cs_vars+[lead]))
+                # get all cs variant pips
+                coding_vars = [a for a in cs_vars_2 if fg_ann.get(a.id,[{"functional_category":"NA"}[0]["functional_category"]!="NA"])]
+                if coding_vars:
+                    max_pip_coding_var = max([(a,cs_ann[a.id]["prob"]) for a in coding_vars],key=lambda x:x[1])[0]                    
+                    #if extra col
+                    # most severe gene and consequence
+                    max_pip_coding_var_fg_ann = fg_ann[max_pip_coding_var.id][0]
+                    max_pip_coding_var_extra_ann = extra_ann.get(max_pip_coding_var.id,[{}])[0]
+                    cols["best_coding_var"] = max_pip_coding_var.id
+                    cols["best_coding_var_consequence"] = max_pip_coding_var_fg_ann["most_severe_consequence"]
+                    cols["best_coding_var_gene"] = max_pip_coding_var_fg_ann["most_severe_gene"]
+                    cols["best_coding_var_af"] = max_pip_coding_var_extra_ann.get("af_alt","NA")
+                    cols["best_coding_var_beta"] = max_pip_coding_var.beta
+                    cols["best_coding_var_p"] = max_pip_coding_var.pval
+            except Exception as e:
+                print("Exception when creating best coding variant annotation in top report: ",e)
         #all traits & strict traits
         #Use CatalogAnnotation
         if CatalogAnnotation.get_name() in data.annotations:

--- a/Scripts/grouping_report.py
+++ b/Scripts/grouping_report.py
@@ -476,7 +476,7 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions)
             try:
                 cs_vars_2 = list(set(cs_vars+[lead]))
                 # get all cs variant pips
-                coding_vars = [a for a in cs_vars_2 if fg_ann.get(a.id,[{"functional_category":"NA"}[0]["functional_category"]!="NA"])]
+                coding_vars = [a for a in cs_vars_2 if fg_ann.get(a.id,[{"functional_category":"NA"}])[0]["functional_category"]!="NA"]
                 if coding_vars:
                     max_pip_coding_var = max([(a,cs_ann[a.id]["prob"]) for a in coding_vars],key=lambda x:x[1])[0]                    
                     #if extra col


### PR DESCRIPTION
Task: https://www.wrike.com/open.htm?id=1619790430
This PR adds in the following columns to group report:
-  best_coding_var :  max PIP coding variant in credible set
- best_coding_var_consequence: its most severe consequence
- best_coding_var_gene: its most severe gene
- best_coding_var_af: its allele frequency, currently taken from summstat extra columns if af_alt is available.
- best_coding_var_beta: Taken from summstat
- best_coding_var_p : Taken from summstat

Questions:
- <del>af_alt is currently hardcoded as the column name for af_alt, meaning this won't work with e.g. meta-analysis. We could use e.g. gnomad FIN AF instead. Or if we add in Finnish AF from finngen annotation, then that can be used. </del>
  - Chose gnomAD for EUR AF and finngen annotation for Finnish AF.