### PR TITLE
Add optional extra columns to previous release annotation

### DIFF
--- a/Scripts/annotation_model.py
+++ b/Scripts/annotation_model.py
@@ -21,7 +21,6 @@ class AnnotationSource:
         """
         pass
 
-    @staticmethod
     @abc.abstractmethod
     def get_output_columns() -> List[str]:
         pass

--- a/Scripts/grouping_report.py
+++ b/Scripts/grouping_report.py
@@ -235,8 +235,6 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions,
     ### List all columns that are created
     lead_cols = [
         "lead_r2_threshold",
-        "lead_beta_previous_release",
-        "lead_pval_previous_release",
         "lead_most_severe_consequence",
         "lead_most_severe_gene",
         "lead_enrichment",

--- a/Scripts/grouping_report.py
+++ b/Scripts/grouping_report.py
@@ -252,6 +252,12 @@ def generate_top_report(data:PhenoData,output:TextIO, options: TopReportOptions,
             lead_c_name = f"lead_{c}"
             if lead_c_name not in lead_cols:
                 lead_cols.append(lead_c_name)
+    if PreviousReleaseAnnotation.get_name() in data.annotations:
+        prev_anno = [a for a in annotations if isinstance(a,PreviousReleaseAnnotation)][0]
+        for c in prev_anno.get_output_columns():
+            lead_c_name = f"lead_{c}"
+            if lead_c_name not in lead_cols:
+                lead_cols.append(lead_c_name)
     columns = [
         "phenotype",
         "phenotype_abbreviation",

--- a/Scripts/grouping_report.py
+++ b/Scripts/grouping_report.py
@@ -67,7 +67,7 @@ def generate_variant_report(data:PhenoData,output:TextIO, options: VariantReport
         options.summstat_options.a,
         options.summstat_options.pval,
         options.summstat_options.beta,
-        "r2_to_lead"] + options.extra_columns+[
+        "r2_to_lead"] +[
         "cs_id",
         "cs_region",
         "cs_number",

--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -74,7 +74,8 @@ def main(args):
             column_names.r,
             column_names.a,
             column_names.pval,
-            column_names.beta)
+            column_names.beta,
+            args.previous_release_additional_columns)
         prevrel_annotation = PreviousReleaseAnnotation(prevrel_opts)
     extra_cols_annotation = ExtraColAnnotation(TabixOptions(
         args.gws_fpath,
@@ -170,8 +171,8 @@ def main(args):
         report_fname = create_fname(args.report_out,args.prefix)
         top_fname = create_fname(args.top_report_out,args.prefix)
         with open(report_fname,"w") as report_file, open(top_fname,"w") as top_file:
-            generate_variant_report(phenodata,report_file,variant_report_options)
-            generate_top_report(phenodata,top_file,top_report_options)
+            generate_variant_report(phenodata,report_file,variant_report_options,annotation_resources)
+            generate_top_report(phenodata,top_file,top_report_options,annotation_resources)
     
 
 def create_fname(path:str,prefix:str)->str:
@@ -211,6 +212,7 @@ if __name__=="__main__":
     parser.add_argument("--finngen-path",dest="finngen_path",type=str,default="",help="Finngen annotation file filepath")
     parser.add_argument("--functional-path",dest="functional_path",type=str,default="",help="File path to functional annotations file")
     parser.add_argument("--previous-release-path",dest="previous_release_path",type=str,default="",help="File path to previous release summary statistic file")
+    parser.add_argument("--previous-release-extra-cols",dest="previous_release_additional_columns",nargs = "*",default=[],help="Additional columns to take from previous release summary statistic file")
     parser.add_argument("--use-gwascatalog",action="store_true",help="Add flag to use GWAS Catalog for comparison.")
     parser.add_argument("--custom-dataresource",type=str,default="",help="Custom dataresource path.")
     parser.add_argument("--report-out",dest="report_out",type=str,default="report_out.tsv",help="Comparison report output path")

--- a/Scripts/main.py
+++ b/Scripts/main.py
@@ -212,7 +212,7 @@ if __name__=="__main__":
     parser.add_argument("--finngen-path",dest="finngen_path",type=str,default="",help="Finngen annotation file filepath")
     parser.add_argument("--functional-path",dest="functional_path",type=str,default="",help="File path to functional annotations file")
     parser.add_argument("--previous-release-path",dest="previous_release_path",type=str,default="",help="File path to previous release summary statistic file")
-    parser.add_argument("--previous-release-extra-cols",dest="previous_release_additional_columns",nargs = "*",default=[],help="Additional columns to take from previous release summary statistic file")
+    parser.add_argument("--previous-release-extra-cols",dest="previous_release_additional_columns",nargs = "*",default=[],help="Additional columns apart from pval and beta to take from previous release summary statistic file")
     parser.add_argument("--use-gwascatalog",action="store_true",help="Add flag to use GWAS Catalog for comparison.")
     parser.add_argument("--custom-dataresource",type=str,default="",help="Custom dataresource path.")
     parser.add_argument("--report-out",dest="report_out",type=str,default="report_out.tsv",help="Comparison report output path")

--- a/wdl/autoreporting.template.json
+++ b/wdl/autoreporting.template.json
@@ -1,6 +1,6 @@
 {
     "autoreporting.input_array_file": "INPUT_MATRIX",
-    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:4a8380d",
+    "autoreporting.docker":"europe-west1-docker.pkg.dev/finngen-refinery-dev/fg-refinery-registry/autorep:a89c5c3",
     "autoreporting.ld_panel":"gs://misc-analysis/EMPTY_FILE",
     "autoreporting.locus_width_kb":2000,
 

--- a/wdl/autoreporting.template.json
+++ b/wdl/autoreporting.template.json
@@ -11,6 +11,7 @@
     "autoreporting.report.functional_annotation":"gs://finngen_commons/annotations/fin_enriched_genomes_select_columns.txt.gz",
     "autoreporting.report.column_names":["#chrom","pos","ref","alt","pval","beta"],
     "autoreporting.report.extra_columns":"mlogp sebeta af_alt af_alt_cases af_alt_controls",
+    "autoreporting.report.previous_release_columns":"mlogp sebeta af_alt af_alt_cases af_alt_controls",
     "autoreporting.report.efo_map":"gs://finngen_commons/autoreporting/efo_map_na.tsv",
     "autoreporting.report.ignore_region":"",
     "autoreporting.report.primary_grouping_method":"cred",

--- a/wdl/autoreporting.wdl
+++ b/wdl/autoreporting.wdl
@@ -47,6 +47,7 @@ task report {
     String db_choice
     Array[String] column_names
     String extra_columns
+    String previous_release_columns
     Float strict_group_r2
     String phenoname = basename(phenotype_name,".gz")
     File dummy_file
@@ -78,6 +79,7 @@ task report {
         finngen_annotation="--finngen-path  ${finngen_annotation}" if "${finngen_annotation}" != empty_file else "" 
         functional_annotation="--functional-path ${functional_annotation}" if "${functional_annotation}" != empty_file else "" 
         previous_release="--previous-release-path ${previous_release}" if "${previous_release}" != empty_file else "" 
+        previous_release_columns = "--previous-release-extra-cols ${previous_release_columns}" if "${previous_release_columns}" != "" else ""
         local_gwascatalog="${"--local-gwascatalog "+ local_gwcatalog}"
 
         sign_treshold=${sign_treshold}
@@ -144,6 +146,7 @@ task report {
                     f"--db {db_choice} "
                     f"--column-labels {column_names} "
                     f"--extra-cols {extra_columns} "
+                    f"{previous_release_columns} "
                     f"{phenotype_info} "
                     f"--gwascatalog-allele-file {alleledb_file} "
                     f"{local_gwascatalog} " #local gwascatalog


### PR DESCRIPTION
This PR adds in the option of including additional columns from the previous release summary statistic.
Usage: add in the extra columns as a space-separated list in the wdl input, like so:
```
"autoreporting.report.previous_release_columns":"mlogp sebeta af_alt af_alt_cases af_alt_controls",
```
This PR also fixes the tabix annotation failing if there were prefixes added to annotation's chromosome column.