### PR TITLE
Change annotations to fetch data over gcs

### DIFF
--- a/Scripts/group_annotation.py
+++ b/Scripts/group_annotation.py
@@ -611,7 +611,7 @@ class CatalogAnnotation(AnnotationSource):
         self.col_rename["pval"] = "pval_trait"
 
     @timefunc
-    def annotate_variants(self,variants:List[Variant]) -> Dict[Variant,Annotation]:
+    def annotate_variants(self,variants:set[Variant]) -> Dict[Variant,Annotation]:
         #generate chromosomal regions, that might be the best for now.
         # The gwas catalog/custom catalog data is not so big, so it will greatly limit 
         # the amount of results coming out.
@@ -619,8 +619,10 @@ class CatalogAnnotation(AnnotationSource):
         # TODO: variant matching etc, and the following rigamarole
         #what columns are output?
         #trait and traitname, pval_trait, study_link
-        chr_d = generate_chrom_ranges(variants)
-        regs = [Region(a,b["start"],b["end"]) for a,b in chr_d.items()]
+        chr_d = generate_chrom_ranges(variants,3_000_000)
+        regs = []
+        for c in chr_d:
+            regs.extend(chr_d[c])
 
         data=self.inner.associations_for_regions(regs)
         #format data according to variant

--- a/Scripts/group_annotation.py
+++ b/Scripts/group_annotation.py
@@ -56,11 +56,11 @@ def generate_chrom_ranges(variants:set[Variant],maximum_range_length:Optional[in
                 #if at beginning, change start to be first pos minus 1 or 0 whichever is bigger
                 if region_start < 0:
                     region_start=max(v.pos-1,0)
-                #if we have started, but the region is not too long yet
-                elif region_end-region_start <= maximum_range_length-1:
+                #if we have started, but the region including this variant is not too large
+                elif v.pos-region_start <= maximum_range_length-1:
                     region_end = v.pos
                 # if we have started, and the region is too long, we wrap up range.
-                elif region_end-region_start > maximum_range_length-1:
+                else:
                     chr_d[c].append(Region(c,region_start,region_end))
                     #if we reset both to -1, then it starts with the next variant correctly.
                     region_start = v.pos
@@ -68,7 +68,6 @@ def generate_chrom_ranges(variants:set[Variant],maximum_range_length:Optional[in
             if region_end != -1 and region_start != -1:
                 chr_d[c].append(Region(c,region_start,region_end))
         return dict(chr_d)
-
 
 class TabixAnnotation(AnnotationSource):
     def __init__(self,opts: TabixOptions):

--- a/Scripts/group_annotation.py
+++ b/Scripts/group_annotation.py
@@ -2,6 +2,7 @@ import re,sys
 from autoreporting_utils import Region
 from data_access.datafactory import db_factory
 from typing import NamedTuple, Optional, List, Dict
+from collections import defaultdict
 
 from grouping_model import CSInfo, PhenoData, Var, Locus
 from data_access.db import CSAccess, Variant, CS
@@ -27,15 +28,46 @@ FUNCTIONAL_CATEGORIES=[
 ]
 
 
-def generate_chrom_ranges(variants:List[Variant])->Dict[str, Dict[str,int]]:
-    chr_d = {}
+def generate_chrom_ranges(variants:set[Variant],maximum_range_length:Optional[int] = None)->Dict[str,list[Region]]:
+    """
+    Generate chromosome ranges, with option for splitting ranges to at most X bp long subranges.
+    """
+    chr_d_input:dict[str,list[Variant]] = defaultdict(list)
     for v in variants:
-        if v.chrom not in chr_d:
-            chr_d[v.chrom] = {"start":v.pos-1,"end":v.pos}
-        else:
-            chr_d[v.chrom]["start"] = max(min(chr_d[v.chrom]["start"],v.pos-1),0)
-            chr_d[v.chrom]["end"] = max(chr_d[v.chrom]["end"],v.pos)
-    return chr_d
+        chr_d_input[v.chrom].append(v)
+    if maximum_range_length is None:
+        chr_d = {}
+        for c in chr_d_input:
+            for v in chr_d_input[c]:
+                if v.chrom not in chr_d:
+                    chr_d[v.chrom] = [
+                        Region(c,v.pos-1,v.pos)
+                    ]
+                else:
+                    chr_d[v.chrom] = [Region(c,max(min(chr_d[v.chrom][0][1],v.pos-1),0),max(chr_d[v.chrom][0][2],v.pos))]
+        return chr_d
+    else:
+        chr_d = defaultdict(list)
+        for c in chr_d_input:
+            sorted_vars = sorted(chr_d_input[c],key=lambda x:x.pos) 
+            region_start = -1
+            region_end = -1
+            for v in sorted_vars:
+                #if at beginning, change start to be first pos minus 1 or 0 whichever is bigger
+                if region_start < 0:
+                    region_start=max(v.pos-1,0)
+                #if we have started, but the region is not too long yet
+                elif region_end-region_start <= maximum_range_length-1:
+                    region_end = v.pos
+                # if we have started, and the region is too long, we wrap up range.
+                elif region_end-region_start > maximum_range_length-1:
+                    chr_d[c].append(Region(c,region_start,region_end))
+                    #if we reset both to -1, then it starts with the next variant correctly.
+                    region_start = v.pos
+                    region_end = v.pos
+            if region_end != -1 and region_start != -1:
+                chr_d[c].append(Region(c,region_start,region_end))
+        return dict(chr_d)
 
 
 class TabixAnnotation(AnnotationSource):
@@ -82,16 +114,17 @@ class TabixAnnotation(AnnotationSource):
             with tb_resource_manager(self.fname,self.cpra[0],self.cpra[1],self.cpra[2],self.cpra[3]) as tabix_resource:
                 hdr = tabix_resource.header
                 hdi = {a:i for i,a in enumerate(hdr)}
-                for chrom_name, region in chr_d.items():
+                for chrom_name, regions in chr_d.items():
                     if self._chrom_to_source(chrom_name) not in self.sequences:
                         print(f"Skipping missing sequence {chrom_name} for annotation {self.fname}",file=sys.stderr)
                         continue
                     chrom_v_set = chr_v_sets[chrom_name]
-                    for l in tabix_resource.fileobject.fetch(self._chrom_to_source(chrom_name),region["start"],region["end"]):
-                        cols = l.split("\t")
-                        v = Variant(self._chrom_from_source(cols[hdi[self.cpra[0]]]),int(cols[hdi[self.cpra[1]]]),cols[hdi[self.cpra[2]]],cols[hdi[self.cpra[3]]] )
-                        if v in chrom_v_set:
-                            output[v] = self._create_annotation(cols,hdi)
+                    for region in regions:
+                        for l in tabix_resource.fetch(self._chrom_to_source(chrom_name),region.start,region.end):
+                            cols = l.split("\t")
+                            v = Variant(self._chrom_from_source(cols[hdi[self.cpra[0]]]),int(cols[hdi[self.cpra[1]]]),cols[hdi[self.cpra[2]]],cols[hdi[self.cpra[3]]] )
+                            if v in chrom_v_set:
+                                output[v] = self._create_annotation(cols,hdi)
         else:
             with tb_resource_manager(self.fname,self.cpra[0],self.cpra[1],self.cpra[2],self.cpra[3]) as tabix_resource:
                 hdr = tabix_resource.header
@@ -105,7 +138,7 @@ class TabixAnnotation(AnnotationSource):
                 for original_v in variants:
                     if self._chrom_to_source(original_v.chrom) not in self.sequences:
                         continue
-                    for l in tabix_resource.fileobject.fetch(self._chrom_to_source(original_v.chrom),max(original_v.pos-1,0),original_v.pos):
+                    for l in tabix_resource.fetch(self._chrom_to_source(original_v.chrom),max(original_v.pos-1,0),original_v.pos):
                         cols = l.split("\t")
                         v = Variant(self._chrom_from_source(cols[hdi[self.cpra[0]]]),int(cols[hdi[self.cpra[1]]]),cols[hdi[self.cpra[2]]],cols[hdi[self.cpra[3]]] )
                         if v in variants:

--- a/Scripts/group_annotation.py
+++ b/Scripts/group_annotation.py
@@ -86,7 +86,7 @@ class TabixAnnotation(AnnotationSource):
         return chrom
 
     def _chrom_from_source(self, chrom:str)->str:
-        """If chromoosme needs modification from tabix source, e.g. removing chr, override this
+        """If chromosome needs modification from tabix source, e.g. removing chr, override this
         """
         return chrom
 
@@ -102,7 +102,7 @@ class TabixAnnotation(AnnotationSource):
         output = {}
         if len(variants) > self.variant_switch:
             #figure out chroms,starts,ends for each one region in chromosome
-            chr_d = generate_chrom_ranges(variants)
+            chr_d = generate_chrom_ranges(variants,3_000_000)
             chr_v_sets:Dict[str,set[Variant]] = {key:set() for key in chr_d.keys()}
             for v in variants:
                 chr_v_sets[v.chrom].add(v)

--- a/Scripts/grouping.py
+++ b/Scripts/grouping.py
@@ -7,7 +7,7 @@ from data_access.csfactory import csfactory
 from time_decorator import timefunc
 
 def ld_threshold(ld_thresh:float, mode: LDMode,pval:float)->float:
-    if mode == LDMode.DYNAMIC:
+    if mode.value == LDMode.DYNAMIC.value:
         return float(min(ld_thresh/stats.chi2.isf(pval,df=1),1.0))
     else:
         return ld_thresh

--- a/Scripts/load_tabix.py
+++ b/Scripts/load_tabix.py
@@ -56,6 +56,39 @@ class TabixResource:
                 self.header = header.split("\t")
         self.hdi = {a:i for i,a in enumerate(self.header)}
 
+    def fetch(self,sequence:str,start:int,end:int)->list[list]:
+        """Fetch data from underlying fileobject.
+        If the object is local, return iterator without first loading all of it.
+        If the object is remote (GCS), first load it to memory so we can atomically either fail or return everything.
+        """
+        if not self.local:
+            # refresh tokens every 20 minutes
+            current_time = time.time()
+            if (current_time - self.token_refresh_time) > 1200.0:
+                print("Refreshing GCS_AUTH_TOKEN",file=sys.stderr)
+                self.refresh_token()
+                self.token_refresh_time = current_time
+            tries = 0
+            while True:
+                try:
+                    iter = self.fileobject.fetch(sequence,start,end)
+                    data = [a for a in iter]
+                    break
+                except:
+                    print(f"Error loading data from region {sequence}:{start}-{end}",file=sys.stderr)
+                    #assume error is in accessing over gcp, so we retry
+                    if tries > MAX_RETRIES:
+                        raise Exception(f"Accessing region {sequence}:{start}-{end} from file {self.fname} failed after {tries} tries!")
+                    
+                    print(f"Error when accessing data from tabix file {self.fname}, assuming error is with access over GCP. Waiting {2**tries} seconds, recycling fileobject.",file=sys.stderr)
+                    time.sleep(2**tries)
+                    self.restart_fileobject()
+                    tries +=1
+            return data
+        else:
+            return self.fileobject.fetch(sequence,start,end)
+
+
     def load_region(self, sequence:str, start:int, end:int, data_columns:List[str])-> Dict[Variant,List[str]]:
         """Load data columns for a region
         NOTE: needs better return format, this is just quite bad to work with

--- a/testing/test_annotation.py
+++ b/testing/test_annotation.py
@@ -19,13 +19,16 @@ class TestAnnotations(unittest.TestCase):
             '3': [Region(chrom='3', start=29, end=30)]}
         self.assertEqual(out,validation)
         out2 = generate_chrom_ranges(set(test_data),maximum_range_length=4)
-        validation2 = {'1': [Region(chrom='1', start=0, end=4),
-              Region(chrom='1', start=5, end=9),
-              Region(chrom='1', start=10, end=14)],
-             '2': [Region(chrom='2', start=14, end=18),
-              Region(chrom='2', start=19, end=23),
-              Region(chrom='2', start=24, end=28),
-              Region(chrom='2', start=29, end=29)]}
+        validation2 = {'2': [
+                Region(chrom='2', start=14, end=17),
+                Region(chrom='2', start=18, end=21),
+                Region(chrom='2', start=22, end=25),
+                Region(chrom='2', start=26, end=29)],
+            '1': [
+                Region(chrom='1', start=0, end=3),
+                Region(chrom='1', start=4, end=7),
+                Region(chrom='1', start=8, end=11),
+                Region(chrom='1', start=12, end=14)]}
         self.assertEqual(out2,validation2)
 
 

--- a/testing/test_annotation.py
+++ b/testing/test_annotation.py
@@ -1,0 +1,35 @@
+import unittest
+import sys
+import pysam
+sys.path.append("../")
+sys.path.append("./")
+sys.path.insert(0, './Scripts')
+#from Scripts.load_tabix import tb_resource_manager,TabixResource
+from Scripts.group_annotation import generate_chrom_ranges
+from Scripts.data_access.db import Variant
+from Scripts.autoreporting_utils import Region
+
+class TestAnnotations(unittest.TestCase):
+
+    def test_generate_ranges(self):
+        test_data = [Variant(str(i//15+1),i,"A","C") for i in range(1,31)]
+        out = generate_chrom_ranges(set(test_data))
+        validation = {'1': [Region(chrom='1', start=0, end=14)],
+            '2': [Region(chrom='2', start=14, end=29)],
+            '3': [Region(chrom='3', start=29, end=30)]}
+        self.assertEqual(out,validation)
+        out2 = generate_chrom_ranges(set(test_data),maximum_range_length=4)
+        validation2 = {'1': [Region(chrom='1', start=0, end=4),
+              Region(chrom='1', start=5, end=9),
+              Region(chrom='1', start=10, end=14)],
+             '2': [Region(chrom='2', start=14, end=18),
+              Region(chrom='2', start=19, end=23),
+              Region(chrom='2', start=24, end=28),
+              Region(chrom='2', start=29, end=29)]}
+        self.assertEqual(out2,validation2)
+
+
+
+
+if __name__=="__main__":
+    unittest.main()

--- a/testing/test_tabixresource.py
+++ b/testing/test_tabixresource.py
@@ -21,6 +21,12 @@ class TestTBResource(unittest.TestCase):
             }
             self.assertEqual(region,validation)
 
+    def test_fetch(self):
+        with tb_resource_manager("testing/db_resources/test_vcf.vcf.gz","#CHROM","POS","REF","ALT") as tbres:
+            region = [a for a in tbres.fetch("1",10018,10039)]
+            validation = ['1\t10019\trs775809821\tTA\tT\t.\t.\tRS=775809821;dbSNPBuildID=144;SSR=0;PSEUDOGENEINFO=DDX11L1:100287102;VC=INDEL', '1\t10039\trs978760828\tA\tC\t.\t.\tRS=978760828;dbSNPBuildID=150;SSR=0;PSEUDOGENEINFO=DDX11L1:100287102;VC=SNV']
+            self.assertEqual(region,validation)
+
     def test_header_skip_file(self):
         with tb_resource_manager("testing/db_resources/skip_header.tsv.gz","chrom","pos","ref","alt") as tbres:
             #validate header

--- a/wdl/autoreporting.template.json
+++ b/wdl/autoreporting.template.json
@@ -1,6 +1,6 @@
 {
     "autoreporting.input_array_file": "INPUT_MATRIX",
-    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:1e98eed",
+    "autoreporting.docker":"eu.gcr.io/finngen-refinery-dev/autorep:be99b57",
     "autoreporting.ld_panel":"gs://r12-data/ld_matrix/finngen_r12_chr{CHROM}_ld.tsv.gz",
     "autoreporting.ld_api":"tabix",
     "autoreporting.locus_width_kb":2000,

--- a/wdl/autoreporting.wdl
+++ b/wdl/autoreporting.wdl
@@ -11,13 +11,13 @@ task report {
     File previous_release = input_file_list[3]
     File previous_release_tbi =previous_release+".tbi" 
 
-    File gnomad
-    File gnomad_tbi = gnomad+".tbi"
+    String gnomad
+    String gnomad_tbi = gnomad+".tbi"
     String ld_panel
-    File finngen_annotation
-    File finngen_annotation_tb=finngen_annotation+".tbi"
-    File functional_annotation
-    File functional_annotation_tb=functional_annotation+".tbi"
+    String finngen_annotation
+    String finngen_annotation_tb=finngen_annotation+".tbi"
+    String functional_annotation
+    String functional_annotation_tb=functional_annotation+".tbi"
 
     File? local_gwcatalog
 
@@ -54,13 +54,8 @@ task report {
     File allele_vcf_file
     File allele_vcf_tbi = allele_vcf_file+".tbi"
 
-    Float disk_size_f = size(summ_stat,"G")+
-        size(previous_release,"G")+
-        size(gnomad,"G")+
-        size(finngen_annotation,"G")+
-        size(functional_annotation,"G")+
-        size(allele_vcf_file,"G")
-    Int disk_size = ceil(disk_size_f*1.25)+75
+
+    Int disk_size = 200
 
     command <<<
         set -euxo pipefail


### PR DESCRIPTION
Following the changes to tabix LD api to work over GCS, the annotation file resources (and every tabix file resource using TabixResource) now works over GCS, so the files do not need to be localized. This should greatly decrease file localization time.
To facilitate the slightly slower querying over the network, the region creation from variants was revamped to make smaller regions. This could likely be optimized by identifying the largest gaps in the variants, and instead placing the gaps there, but profiling is needed to determine if there's a problem here or not.